### PR TITLE
skip filter feature

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -2,4 +2,4 @@ Aamna Lawrence <aamna.lawrence@gmail.com>
 Adam Li <adam2392@gmail.com>
 Victor Xiang <xiangliang3151@gmail.com>
 Victor Xiang <xiangliang3151@gmail.com> <32950290+Nick3151@users.noreply.github.com>
-Yorguin Mantilla <36543115+yjmantilla@users.noreply.github.com>
+Yorguin Mantilla <yjmantilla@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -3,3 +3,4 @@ Adam Li <adam2392@gmail.com>
 Victor Xiang <xiangliang3151@gmail.com>
 Victor Xiang <xiangliang3151@gmail.com> <32950290+Nick3151@users.noreply.github.com>
 Yorguin Mantilla <yjmantilla@gmail.com>
+Yorguin Mantilla <yjmantilla@gmail.com> <36543115+yjmantilla@users.noreply.github.com>

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -31,7 +31,7 @@ Current
 Changelog
 ~~~~~~~~~
 
-- It's now possible to pass an empty list to skip the line noise removal by `Yorguin Mantilla`_ (`#29 <https://github.com/sappelhoff/pyprep/pull/29>`_)
+- It's now possible to pass an empty list for the ``line_freqs`` param in ``PrepPipeline`` to skip the line noise removal, by `Yorguin Mantilla`_ (`#29 <https://github.com/sappelhoff/pyprep/pull/29>`_)
 
 Bug
 ~~~

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -31,7 +31,7 @@ Current
 Changelog
 ~~~~~~~~~
 
-- nothing yet
+- It's now possible to pass an empty list to skip the line noise removal by `Yorguin Mantilla`_ (`#29 <https://github.com/sappelhoff/pyprep/pull/29>`_)
 
 Bug
 ~~~

--- a/pyprep/prep_pipeline.py
+++ b/pyprep/prep_pipeline.py
@@ -70,22 +70,23 @@ class PrepPipeline:
         # )
         # reference_channels = _set_diff(self.prep_params["ref_chs"], unusable_channels)
         # Step 1: 1Hz high pass filtering
-        self.EEG_new = removeTrend(self.EEG_raw, sample_rate=self.sfreq)
+        if len(self.prep_params["line_freqs"]) != 0:
+            self.EEG_new = removeTrend(self.EEG_raw, sample_rate=self.sfreq)
 
-        # Step 2: Removing line noise
-        linenoise = self.prep_params["line_freqs"]
-        self.EEG_clean = mne.filter.notch_filter(
-            self.EEG_new,
-            Fs=self.sfreq,
-            freqs=linenoise,
-            method="spectrum_fit",
-            mt_bandwidth=2,
-            p_value=0.01,
-        )
+            # Step 2: Removing line noise
+            linenoise = self.prep_params["line_freqs"]
+            self.EEG_clean = mne.filter.notch_filter(
+                self.EEG_new,
+                Fs=self.sfreq,
+                freqs=linenoise,
+                method="spectrum_fit",
+                mt_bandwidth=2,
+                p_value=0.01,
+            )
 
-        # Add Trend back
-        self.EEG = self.EEG_raw - self.EEG_new + self.EEG_clean
-        self.raw._data = self.EEG * 1e-6
+            # Add Trend back
+            self.EEG = self.EEG_raw - self.EEG_new + self.EEG_clean
+            self.raw._data = self.EEG * 1e-6
 
         # Step 3: Referencing
         reference = Reference(self.raw, self.prep_params, ransac=self.ransac)

--- a/pyprep/prep_pipeline.py
+++ b/pyprep/prep_pipeline.py
@@ -28,8 +28,9 @@ class PrepPipeline:
             - A list of channel names to be used for line-noise removed, and
               referenced [default: all channels]
 
-        - line_freqs : 1d array
-            - A list of line frequencies to be removed
+        - line_freqs : array_like
+            - list of floats indicating frequencies to be removed.
+              Can be an empty list to skip this step.
 
     montage : DigMontage
         Digital montage of EEG data.


### PR DESCRIPTION
Explanation:

If the multitaper filter is skipped there is no need to remove the trend at the beginning since the trend at that point is specifically removed for the multitaper filter and then added back. So if we skip the filter we can jump directly to the robust referencing.