### PR TITLE
lesser ram ransac

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -30,7 +30,7 @@ Current
 
 Changelog
 ~~~~~~~~~
-- It's now possible to automatically use a less ram hungry (but slower) version of the ransac if it is needed, by `Yorguin Mantilla`_ (`#32 <https://github.com/sappelhoff/pyprep/pull/32>`_)
+- When a ransac call needs more memory than available, pyprep will now automatically switch to a slower but less memory-consuming version of ransac. See the ``channel_wise``parameter, by `Yorguin Mantilla`_ (`#32 <https://github.com/sappelhoff/pyprep/pull/32>`_)
 - It's now possible to pass an empty list for the ``line_freqs`` param in ``PrepPipeline`` to skip the line noise removal, by `Yorguin Mantilla`_ (`#29 <https://github.com/sappelhoff/pyprep/pull/29>`_)
 - The three main classes ``PrepPipeline``, ``NoisyChannels``, and ``Reference`` now have a ``random_state`` parameter to set a seed that gets passed on to all their internal methods and class calls, by `Stefan Appelhoff`_ (`#31 <https://github.com/sappelhoff/pyprep/pull/31>`_)
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -30,7 +30,7 @@ Current
 
 Changelog
 ~~~~~~~~~
-
+- It's now possible to automatically use a less ram hungry (but slower) version of the ransac if it is needed, by `Yorguin Mantilla`_ (`#32 <https://github.com/sappelhoff/pyprep/pull/32>`_)
 - It's now possible to pass an empty list for the ``line_freqs`` param in ``PrepPipeline`` to skip the line noise removal, by `Yorguin Mantilla`_ (`#29 <https://github.com/sappelhoff/pyprep/pull/29>`_)
 - The three main classes ``PrepPipeline``, ``NoisyChannels``, and ``Reference`` now have a ``random_state`` parameter to set a seed that gets passed on to all their internal methods and class calls, by `Stefan Appelhoff`_ (`#31 <https://github.com/sappelhoff/pyprep/pull/31>`_)
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -38,7 +38,9 @@ Changelog
 Bug
 ~~~
 
-- nothing yet
+- Corrected inconsistentcy of :mod:`reference` with the matlab version (`#19 <https://github.com/sappelhoff/pyprep/issues/19>`_), by `Yorguin Mantilla`_ (`#32 <https://github.com/sappelhoff/pyprep/pull/32>`_)
+- Prevented an over detrending in :mod:`reference`, by `Yorguin Mantilla`_ (`#32 <https://github.com/sappelhoff/pyprep/pull/32>`_)
+
 
 API
 ~~~

--- a/examples/run_ransac.py
+++ b/examples/run_ransac.py
@@ -77,6 +77,7 @@ start_time = perf_counter()
 nd.find_bad_by_ransac()
 print("--- %s seconds ---" % (perf_counter() - start_time))
 
+# Repeat RANSAC in a channel wise manner. This is slower but needs less memory.
 start_time = perf_counter()
 nd2.find_bad_by_ransac(channel_wise=True)
 print("--- %s seconds ---" % (perf_counter() - start_time))

--- a/examples/run_ransac.py
+++ b/examples/run_ransac.py
@@ -91,5 +91,6 @@ print("--- %s seconds ---" % (perf_counter() - start_time))
 print(nd.bad_by_ransac)
 assert set(bad_ch_names) == set(nd.bad_by_ransac)
 
+# Check that the channel wise RANSAC yields identical results
 print(nd2.bad_by_ransac)
 assert set(bad_ch_names) == set(nd2.bad_by_ransac)

--- a/examples/run_ransac.py
+++ b/examples/run_ransac.py
@@ -24,9 +24,9 @@ from pyprep.find_noisy_channels import NoisyChannels
 ###############################################################################
 # Now let's make some arbitrary MNE raw object for demonstration purposes.
 # We will think of good channels as sine waves and bad channels correlated with
-# each other as sawtooths. The idea is that the RANSAC is able to identify
-# these channels. We will need to set a montage because the RANSAC needs to
-# interpolate.
+# each other as sawtooths. The RANSAC will be biased towards sines in its
+# prediction (they are the majority) so it will identify the sawtooths as bad.
+# We will need to set a montage because the RANSAC needs to interpolate.
 
 sfreq = 1000.0
 

--- a/examples/run_ransac.py
+++ b/examples/run_ransac.py
@@ -69,12 +69,16 @@ raw.set_montage(montage, verbose=False)
 # will be the place where all following methods are performed.
 
 nd = NoisyChannels(raw)
-
+nd2 = NoisyChannels(raw)
 
 ###############################################################################
 # Find all bad channels and print a summary
 start_time = perf_counter()
 nd.find_bad_by_ransac()
+print("--- %s seconds ---" % (perf_counter() - start_time))
+
+start_time = perf_counter()
+nd2.find_bad_by_ransac(channel_wise=True)
 print("--- %s seconds ---" % (perf_counter() - start_time))
 
 ###############################################################################
@@ -85,3 +89,6 @@ print("--- %s seconds ---" % (perf_counter() - start_time))
 # Check channels that go bad together by correlation (RANSAC)
 print(nd.bad_by_ransac)
 assert set(bad_ch_names) == set(nd.bad_by_ransac)
+
+print(nd2.bad_by_ransac)
+assert set(bad_ch_names) == set(nd2.bad_by_ransac)

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -10,7 +10,7 @@ from statsmodels import robust
 
 from pyprep.removeTrend import removeTrend
 from pyprep.utils import filter_design
-from pyprep.utils import SplitList
+from pyprep.utils import split_list
 
 
 class NoisyChannels:
@@ -469,7 +469,7 @@ class NoisyChannels:
 
         while mem_error:
             try:
-                channel_chunks = SplitList(job, chunk_size)
+                channel_chunks = split_list(job, chunk_size)
                 total_chunks = len(channel_chunks)
                 print("Total # of chunks:", total_chunks)
                 current = 1

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -499,7 +499,8 @@ class NoisyChannels:
                 )
                 if chunk_size == 0:
                     raise MemoryError(
-                        "Not even doing 1 channel at a time the data fits in ram...\nMaybe try lowering the sample frequency."
+                        "Not even doing 1 channel at a time the data fits in ram..."
+                        "\nMaybe try lowering the sample frequency."
                     )
 
         # Thresholding

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -501,7 +501,6 @@ class NoisyChannels:
 
             # Preallocate
             channel_correlations = np.ones((w_correlation, self.n_chans_new))
-            # print("RANSAC PREDICTIONS:" + str(self.n_chans_new))
 
             for chanx in range(self.EEGData.shape[0]):
                 # Make the ransac predictions
@@ -538,12 +537,11 @@ class NoisyChannels:
                     # This transformation get us to the diagonal elements
                     # although we could do it by slicing too
                     channel_correlations[k, chanx] = R
-                # print(chanx, end=" ")
 
         # Thresholding
         thresholded_correlations = channel_correlations < corr_thresh
         frac_bad_corr_windows = np.mean(thresholded_correlations, axis=0)
-        # print("\nRANSAC DONE\n")
+
         # find the corresponding channel names and return
         bad_ransac_channels_idx = np.argwhere(frac_bad_corr_windows > fraction_bad)
         bad_ransac_channels_name = self.ch_names_new[

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -477,7 +477,7 @@ class NoisyChannels:
 
         except MemoryError:
             print("Cannot allocate enough ram for optimized ransac.")
-            print("Attempting channel-wise ransac... it is slower :( .")
+            print("Attempting channel-wise ransac... but it is slower :( .")
             print("\nRANSAC PREDICTIONS:" + str(self.n_chans_new))
             for chanx in range(self.n_chans_new):
                 chans_to_predict = [chanx]

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -368,10 +368,7 @@ class NoisyChannels:
         self.find_bad_by_correlation()
         set_hf = set(self.bad_by_hf_noise)
         set_correlation = set(self.bad_by_correlation)
-        not_hf = set_correlation - set_hf
-        self.bad_by_SNR = self.bad_by_hf_noise + list(not_hf)
-        # this could have been done by an intersection
-        # self.bad_by_SNR = set_correlation.intersection(set_hf)
+        self.bad_by_SNR = list(set_correlation.intersection(set_hf))
         return None
 
     def find_bad_by_ransac(

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -482,7 +482,7 @@ class NoisyChannels:
                 R = np.diag(R[0 : self.n_chans_new, self.n_chans_new :])
                 channel_correlations[k, :] = R
 
-        except:
+        except MemoryError:
             print("Cannot allocate enough ram for optimized ransac")
             print("Attempting Slow Ransac")
             # Correlate ransac prediction and eeg data

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -502,8 +502,8 @@ class NoisyChannels:
                 if chunk_size == 0:
                     raise MemoryError(
                         "Not even doing 1 channel at a time the data fits in ram..."
-                        "You could downsample the data or reduce the number of requested"
-                        " samples."
+                        "You could downsample the data or reduce the number of requ"
+                        "ested samples."
                     )
 
         # Thresholding

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -580,12 +580,15 @@ class NoisyChannels:
             The EEG data predicted by RANSAC
 
         """
+        # n_chns, n_timepts = data.shape
+        # 2 next lines should be equivalent but support single channel processing
+        n_timepts = data.shape[1]
+        n_chns = chn_pos.shape[0]
+
         # Before running, make sure we have enough memory
         try:
             available_gb = virtual_memory().available * 1e-9
-            needed_gb = (
-                data[: chn_pos.shape[0], :].nbytes * 1e-9
-            ) * n_samples  # chn_pos.shape[0] is just n_chans
+            needed_gb = (data[:n_chns, :].nbytes * 1e-9) * n_samples
             assert available_gb > needed_gb
         except AssertionError:
             raise MemoryError(
@@ -599,10 +602,6 @@ class NoisyChannels:
 
         # Memory seems to be fine ...
         # Make the predictions
-        # n_chns, n_timepts = data.shape
-        # 2 next lines should be equivalent but support single channel processing
-        n_timepts = data.shape[1]
-        n_chns = chn_pos.shape[0]
         eeg_predictions = np.zeros((n_chns, n_timepts, n_samples))
         for sample in range(n_samples):
             eeg_predictions[..., sample] = self.get_ransac_pred(

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -465,14 +465,11 @@ class NoisyChannels:
 
         if channel_wise:
             chunk_size = 1
-
         while mem_error:
             try:
                 channel_chunks = split_list(job, chunk_size)
                 total_chunks = len(channel_chunks)
-                print("Total # of chunks:", total_chunks)
                 current = 1
-                print("Current chunk:", end=" ", flush=True)
                 for chunk in channel_chunks:
                     channel_correlations[:, chunk] = self.ransac_correlations(
                         chunk,
@@ -485,19 +482,20 @@ class NoisyChannels:
                         n,
                         w_correlation,
                     )
+                    if chunk == channel_chunks[0]:
+                        # If it gets here, it means it is the optimal
+                        print("Finding optimal chunk size :", chunk_size)
+                        print("Total # of chunks:", total_chunks)
+                        print("Current chunk:", end=" ", flush=True)
+
                     print(current, end=" ", flush=True)
                     current = current + 1
 
                 mem_error = False  # All chunks processed, hurray!
                 del current
             except MemoryError:
-                print("Cannot allocate enough ram for chunk size :", chunk_size)
-                chunk_size = chunk_size // 2
-                print(
-                    "Splitting chunk size by half =",
-                    chunk_size,
-                    "but it will be slower :(",
-                )
+                chunk_size = chunk_size - 1  # // 2
+                # dividing strategy may miss the most optimal chunk size
                 if chunk_size == 0:
                     raise MemoryError(
                         "Not even doing 1 channel at a time the data fits in ram..."

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -534,9 +534,9 @@ class NoisyChannels:
 
                     # R in this case is a 2x2 matrix with main diagonal elements = 1
                     # The counter diagonal elements are the values we are interested in
-                    R = np.diag(
-                        R[0:1, 1:]
-                    )  # This transformation get us to the diagonal elements, although we could do it by slicing too
+                    R = np.diag(R[0:1, 1:])
+                    # This transformation get us to the diagonal elements
+                    # although we could do it by slicing too
                     channel_correlations[k, chanx] = R
                 # print(chanx, end=" ")
 

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -288,7 +288,9 @@ class NoisyChannels:
         frac_bad : float
             percentage of data windows in which the correlation threshold was
             not surpassed and if a channel gets a value of greater than 1%, it
-            is designated bad.
+            is designated bad. Notice that if the # of windows is low the default
+            frac_bad may be too extreme (ie 60 windows imply only 1 bad window
+            needed).
 
         """
         self.find_bad_by_hfnoise()  # since filtering is performed there

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -288,9 +288,11 @@ class NoisyChannels:
         frac_bad : float
             percentage of data windows in which the correlation threshold was
             not surpassed and if a channel gets a value of greater than 1%, it
-            is designated bad. Notice that if the # of windows is low the default
-            frac_bad may be too extreme (ie 60 windows imply only 1 bad window
-            needed).
+            is designated bad. Notice that if `correlation_secs` is high, and
+            thus the number of windows is low, the default `frac_bad` may
+            be too extreme. For example if only 60 windows are available
+            for a dataset, only a single bad window would be needed to
+            classify as bad.
 
         """
         self.find_bad_by_hfnoise()  # since filtering is performed there

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -647,7 +647,6 @@ class NoisyChannels:
         w_correlation: int
             Number of windows.
         """
-
         # Preallocate
         channel_correlations = np.ones((w_correlation, len(chans_to_predict)))
 

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -438,59 +438,113 @@ class NoisyChannels:
                 " quality tests."
             )
 
-        # Make the ransac predictions
-        ransac_eeg = self.run_ransac(
-            chn_pos=chn_pos,
-            chn_pos_good=chn_pos_good,
-            good_chn_labs=good_chn_labs,
-            n_pred_chns=n_pred_chns,
-            data=self.EEGData,
-            n_samples=n_samples,
-        )
+        try:
+            # Make the ransac predictions
+            ransac_eeg = self.run_ransac(
+                chn_pos=chn_pos,
+                chn_pos_good=chn_pos_good,
+                good_chn_labs=good_chn_labs,
+                n_pred_chns=n_pred_chns,
+                data=self.EEGData,
+                n_samples=n_samples,
+            )
 
-        # Correlate ransac prediction and eeg data
-        correlation_frames = corr_window_secs * self.sample_rate
-        correlation_window = np.arange(correlation_frames)
-        n = correlation_window.shape[0]
-        correlation_offsets = np.arange(
-            0, (self.signal_len - correlation_frames), correlation_frames
-        )
-        w_correlation = correlation_offsets.shape[0]
+            # Correlate ransac prediction and eeg data
+            correlation_frames = corr_window_secs * self.sample_rate
+            correlation_window = np.arange(correlation_frames)
+            n = correlation_window.shape[0]
+            correlation_offsets = np.arange(
+                0, (self.signal_len - correlation_frames), correlation_frames
+            )
+            w_correlation = correlation_offsets.shape[0]
 
-        # For the actual data
-        data_window = self.EEGData[: self.n_chans_new, : n * w_correlation]
-        data_window = data_window.reshape(self.n_chans_new, n, w_correlation)
+            # For the actual data
+            data_window = self.EEGData[: self.n_chans_new, : n * w_correlation]
+            data_window = data_window.reshape(self.n_chans_new, n, w_correlation)
 
-        # For the ransac predicted eeg
-        pred_window = ransac_eeg[: self.n_chans_new, : n * w_correlation]
-        pred_window = pred_window.reshape(self.n_chans_new, n, w_correlation)
+            # For the ransac predicted eeg
+            pred_window = ransac_eeg[: self.n_chans_new, : n * w_correlation]
+            pred_window = pred_window.reshape(self.n_chans_new, n, w_correlation)
 
-        # Preallocate
-        channel_correlations = np.ones((w_correlation, self.n_chans_new))
+            # Preallocate
+            channel_correlations = np.ones((w_correlation, self.n_chans_new))
 
-        # Perform correlations
-        for k in range(w_correlation):
-            data_portion = data_window[:, :, k]
-            pred_portion = pred_window[:, :, k]
+            # Perform correlations
+            for k in range(w_correlation):
+                data_portion = data_window[:, :, k]
+                pred_portion = pred_window[:, :, k]
 
-            R = np.corrcoef(data_portion, pred_portion)
+                R = np.corrcoef(data_portion, pred_portion)
 
-            # Take only correlations of data with pred
-            # and use diag to exctract correlation of
-            # data_i with pred_i
-            R = np.diag(R[0 : self.n_chans_new, self.n_chans_new :])
-            channel_correlations[k, :] = R
+                # Take only correlations of data with pred
+                # and use diag to exctract correlation of
+                # data_i with pred_i
+                R = np.diag(R[0 : self.n_chans_new, self.n_chans_new :])
+                channel_correlations[k, :] = R
+
+        except:
+            print("Cannot allocate enough ram for optimized ransac")
+            print("Attempting Slow Ransac")
+            # Correlate ransac prediction and eeg data
+            correlation_frames = corr_window_secs * self.sample_rate
+            correlation_window = np.arange(correlation_frames)
+            n = correlation_window.shape[0]
+
+            correlation_offsets = np.arange(
+                0, (self.signal_len - correlation_frames), correlation_frames
+            )
+            w_correlation = correlation_offsets.shape[0]
+
+            # Preallocate
+            channel_correlations = np.ones((w_correlation, self.n_chans_new))
+            # print("RANSAC PREDICTIONS:" + str(self.n_chans_new))
+
+            for chanx in range(self.EEGData.shape[0]):
+                # Make the ransac predictions
+                ransac_eeg = self.run_ransac(
+                    chn_pos=chn_pos[[chanx], :],
+                    chn_pos_good=chn_pos_good,
+                    good_chn_labs=good_chn_labs,
+                    n_pred_chns=n_pred_chns,
+                    data=self.EEGData,
+                    n_samples=n_samples,
+                )
+
+                # For the actual data
+                data_window = self.EEGData[chanx, : n * w_correlation]
+                data_window = data_window.reshape(1, n, w_correlation)
+
+                # For the ransac predicted eeg
+                pred_window = ransac_eeg[0, : n * w_correlation]
+                pred_window = pred_window.reshape(1, n, w_correlation)
+
+                # Perform correlations
+                for k in range(w_correlation):
+                    data_portion = data_window[:, :, k]
+                    pred_portion = pred_window[:, :, k]
+
+                    R = np.corrcoef(data_portion, pred_portion)
+
+                    # Take only correlations of data with pred
+                    # and use diag to exctract correlation of
+                    # data_i with pred_i
+                    R = np.diag(
+                        R[0:1, 1:]
+                    )  # This was a matrix but Im looking for a single value
+                    channel_correlations[k, chanx] = R
+                # print(chanx, end=" ")
 
         # Thresholding
         thresholded_correlations = channel_correlations < corr_thresh
         frac_bad_corr_windows = np.mean(thresholded_correlations, axis=0)
-
+        # print("\nRANSAC DONE\n")
         # find the corresponding channel names and return
         bad_ransac_channels_idx = np.argwhere(frac_bad_corr_windows > fraction_bad)
         bad_ransac_channels_name = self.ch_names_new[
             bad_ransac_channels_idx.astype(int)
         ]
         self.bad_by_ransac = [i[0] for i in bad_ransac_channels_name]
+
         return None
 
     def run_ransac(
@@ -525,7 +579,9 @@ class NoisyChannels:
         # Before running, make sure we have enough memory
         try:
             available_gb = virtual_memory().available * 1e-9
-            needed_gb = (data.nbytes * 1e-9) * n_samples
+            needed_gb = (
+                data[: chn_pos.shape[0], :].nbytes * 1e-9
+            ) * n_samples  # chn_pos.shape[0] is just n_chans
             assert available_gb > needed_gb
         except AssertionError:
             raise MemoryError(
@@ -539,7 +595,10 @@ class NoisyChannels:
 
         # Memory seems to be fine ...
         # Make the predictions
-        n_chns, n_timepts = data.shape
+        # n_chns, n_timepts = data.shape
+        # 2 next lines should be equivalent but support single channel processing
+        n_timepts = data.shape[1]
+        n_chns = chn_pos.shape[0]
         eeg_predictions = np.zeros((n_chns, n_timepts, n_samples))
         for sample in range(n_samples):
             eeg_predictions[..., sample] = self.get_ransac_pred(

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -502,7 +502,8 @@ class NoisyChannels:
                 if chunk_size == 0:
                     raise MemoryError(
                         "Not even doing 1 channel at a time the data fits in ram..."
-                        "\nMaybe try lowering the sample frequency."
+                        "You could downsample the data or reduce the number of requested"
+                        " samples."
                     )
 
         # Thresholding

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -73,21 +73,15 @@ class Reference:
         """
         # Phase 1: Estimate the true signal mean with robust referencing
         self.robust_reference()
-        if self.noisy_channels["bad_all"]:
-            # If we interpolate the raw here we would be interpolating
-            # more than what we actually account for later.
-            dummy = self.raw.copy()
-            dummy.info["bads"] = self.noisy_channels["bad_all"]
-            dummy.interpolate_bads()
-            self.reference_signal = (
-                np.nanmean(dummy.get_data(picks=self.reference_channels), axis=0) * 1e6
-            )
-            del dummy
-        else:
-            self.reference_signal = (
-                np.nanmean(self.raw.get_data(picks=self.reference_channels), axis=0)
-                * 1e6
-            )
+        # If we interpolate the raw here we would be interpolating
+        # more than what we later actually account for (in interpolated channels).
+        dummy = self.raw.copy()
+        dummy.info["bads"] = self.noisy_channels["bad_all"]
+        dummy.interpolate_bads()
+        self.reference_signal = (
+            np.nanmean(dummy.get_data(picks=self.reference_channels), axis=0) * 1e6
+        )
+        del dummy
         rereferenced_index = [
             self.ch_names_eeg.index(ch) for ch in self.rereferenced_channels
         ]
@@ -194,7 +188,6 @@ class Reference:
 
         # Remove reference from signal, iteratively interpolating bad channels
         raw_tmp = raw.copy()
-
         iterations = 0
         noisy_channels_old = []
         max_iteration_num = 4

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -171,10 +171,11 @@ class Reference:
             noisy_detector.bad_by_nan, noisy_detector.bad_by_flat
         )
 
-        # Original Matlab Implementation
-        # see unusableChannels = union(badChannelsFromNaNs, union(badChannelsFromNoData, badChannelsFromLowSNR));
-        # see badChannelsFromLowSNR = intersect(noisy.badChannelsFromHFNoise, noisy.badChannelsFromCorrelation);
-        # self.unusable_channels = _union(self.unusable_channels, noisy_detector.bad_by_SNR)
+        # According to the Matlab Implementation (see robustReference.m)
+        # self.unusable_channels = _union(self.unusable_channels,
+        # noisy_detector.bad_by_SNR)
+        # but maybe this makes no difference...
+
         self.reference_channels = _set_diff(
             self.reference_channels, self.unusable_channels
         )

--- a/pyprep/utils.py
+++ b/pyprep/utils.py
@@ -64,3 +64,29 @@ def filter_design(N_order, amp, freq):
     )
     kernel = np.multiply(kernel[0 : N_order + 1], (np.transpose(hamming_window[:])))
     return kernel
+
+
+def SplitList(mylist, chunk_size):
+    """Split list in chunks.
+
+    Parameters
+    ----------
+    my_list: list
+        list to split.
+    chunk_size: int
+        size of the lists returned.
+
+    Returns
+    -------
+    chunked lists: list
+        list of the chunked lists.
+
+
+    Code taken from:
+    https://stackoverflow.com/questions/312443/how-do-you-split-a-list-into-evenly-sized-chunks
+
+    Authors: atzz,cardamom from stackoverflow.
+    """
+    return [
+        mylist[offs : offs + chunk_size] for offs in range(0, len(mylist), chunk_size)
+    ]

--- a/pyprep/utils.py
+++ b/pyprep/utils.py
@@ -66,7 +66,7 @@ def filter_design(N_order, amp, freq):
     return kernel
 
 
-def SplitList(mylist, chunk_size):
+def split_list(mylist, chunk_size):
     """Split list in chunks.
 
     Parameters
@@ -81,11 +81,7 @@ def SplitList(mylist, chunk_size):
     chunked lists: list
         list of the chunked lists.
 
-
-    Code taken from:
-    https://stackoverflow.com/questions/312443/how-do-you-split-a-list-into-evenly-sized-chunks
-
-    Authors: atzz,cardamom from stackoverflow.
+    See: https://stackoverflow.com/a/312466/5201771
     """
     return [
         mylist[offs : offs + chunk_size] for offs in range(0, len(mylist), chunk_size)

--- a/tests/test_find_noisy_channels.py
+++ b/tests/test_find_noisy_channels.py
@@ -128,3 +128,13 @@ def test_findnoisychannels(raw, montage):
     nd.find_bad_by_ransac(channel_wise=True)
     bads = nd.bad_by_ransac
     assert bads == raw_tmp.ch_names[0:6]
+
+    # Test too little ram memory error
+    raw_tmp = raw.copy()
+    raw_tmp._data[0:6, :] = np.cos(2 * np.pi * raw.times * 30) * 1e-6
+    nd = NoisyChannels(raw_tmp, random_state=rng)
+
+    # Set n_samples very very high to trigger a memory error
+    n_samples = 1e100
+    with pytest.raises(MemoryError):
+        nd.find_bad_by_ransac(n_samples=n_samples)

--- a/tests/test_find_noisy_channels.py
+++ b/tests/test_find_noisy_channels.py
@@ -118,3 +118,13 @@ def test_findnoisychannels(raw, montage):
     nd.find_bad_by_ransac()
     bads = nd.bad_by_ransac
     assert bads == raw_tmp.ch_names[0:6]
+
+    # Test for finding bad channels by channel-wise RANSAC
+    raw_tmp = raw.copy()
+    # Ransac identifies channels that go bad together and are highly correlated.
+    # Inserting highly correlated signal in channels 0 through 3 at 30 Hz
+    raw_tmp._data[0:6, :] = np.cos(2 * np.pi * raw.times * 30) * 1e-6
+    nd = NoisyChannels(raw_tmp, random_state=rng)
+    nd.find_bad_by_ransac(channel_wise=True)
+    bads = nd.bad_by_ransac
+    assert bads == raw_tmp.ch_names[0:6]


### PR DESCRIPTION
# PR Description

Adding a lesser hungry version of the ransac albeit slower since it is done channel by channel. As of now it will try to execute the fast ransac and if that fails will try to do the channel-wise ransac. It is about 5 to 6 times slower than the ram hungry version.

Would close #17 and close #19 also closes #28 

Edit: Optimized, now ransac will automatically find the largest chunk of channels it can take at a time without running out of ram.