### PR TITLE
Adopt windowed approach to spectrum fit notch filtering as the new default

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -32,7 +32,8 @@ Current
 
 Changelog
 ~~~~~~~~~
-
+- It's now possible to pass kwargs arguments to the notch filter inside prep; see the ``filter_kwargs`` parameter by `Yorguin Mantilla`_ (`#40 <https://github.com/sappelhoff/pyprep/pull/40>`_)
+- The default filter length for the spectrum_fit method will be '10s' to fix memory issues, by `Yorguin Mantilla`_ (`#40 <https://github.com/sappelhoff/pyprep/pull/40>`_)
 - Channel types  are now available from a new ``ch_types_all`` attribute, and non-EEG channel names are now available from a new ``ch_names_non_eeg`` attribute from :class:`pyprep.PrepPipeline`, by `Yorguin Mantilla`_ (`#34 <https://github.com/sappelhoff/pyprep/pull/34>`_)
 - Renaming of ``ch_names`` attribute of ``PrepPipeline`` to ``ch_names_all``, by `Yorguin Mantilla`_ (`#34 <https://github.com/sappelhoff/pyprep/pull/34>`_)
 - It's now possible to pass ``'eeg'`` to ``ref_chs`` and ``reref_chs`` parameters to select only eeg channels for referencing, by `Yorguin Mantilla`_ (`#34 <https://github.com/sappelhoff/pyprep/pull/34>`_)

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -32,7 +32,7 @@ Current
 
 Changelog
 ~~~~~~~~~
-- It's now possible to pass kwargs arguments to the notch filter inside prep; see the ``filter_kwargs`` parameter by `Yorguin Mantilla`_ (`#40 <https://github.com/sappelhoff/pyprep/pull/40>`_)
+- It's now possible to pass keyword arguments to the notch filter inside prep; see the ``filter_kwargs`` parameter by `Yorguin Mantilla`_ (`#40 <https://github.com/sappelhoff/pyprep/pull/40>`_)
 - The default filter length for the spectrum_fit method will be '10s' to fix memory issues, by `Yorguin Mantilla`_ (`#40 <https://github.com/sappelhoff/pyprep/pull/40>`_)
 - Channel types  are now available from a new ``ch_types_all`` attribute, and non-EEG channel names are now available from a new ``ch_names_non_eeg`` attribute from :class:`pyprep.PrepPipeline`, by `Yorguin Mantilla`_ (`#34 <https://github.com/sappelhoff/pyprep/pull/34>`_)
 - Renaming of ``ch_names`` attribute of ``PrepPipeline`` to ``ch_names_all``, by `Yorguin Mantilla`_ (`#34 <https://github.com/sappelhoff/pyprep/pull/34>`_)

--- a/pyprep/prep_pipeline.py
+++ b/pyprep/prep_pipeline.py
@@ -42,7 +42,7 @@ class PrepPipeline:
         (see RandomState for details). Default is None.
     filter_kwargs : dictionary
         Keywords arguments for the mne.filter.notch_filter function.
-        Note Fs and freqs are already setted up by the prep_params dictionary.
+        Note Fs and freqs are already set up by the prep_params dictionary.
 
     Attributes
     ----------

--- a/pyprep/prep_pipeline.py
+++ b/pyprep/prep_pipeline.py
@@ -40,9 +40,12 @@ class PrepPipeline:
         an int, it will be used as a seed for RandomState.
         If None, the seed will be obtained from the operating system
         (see RandomState for details). Default is None.
-    filter_kwargs : dictionary
-        Keywords arguments for the mne.filter.notch_filter function.
-        Note Fs and freqs are already set up by the prep_params dictionary.
+    filter_kwargs : dict | None
+        Optional keywords arguments to be passed on to mne.filter.notch_filter.
+        Do not set the "x", Fs", and "freqs" arguments via the filter_kwargs
+        parameter, but use the "raw" and "prep_params" parameters instead.
+        If None is passed, the pyprep default settings for filtering are used
+        instead.
 
     Attributes
     ----------

--- a/pyprep/prep_pipeline.py
+++ b/pyprep/prep_pipeline.py
@@ -40,6 +40,9 @@ class PrepPipeline:
         an int, it will be used as a seed for RandomState.
         If None, the seed will be obtained from the operating system
         (see RandomState for details). Default is None.
+    filter_kwargs : dictionary
+        Keywords arguments for the mne.filter.notch_filter function.
+        Note Fs and freqs are already setted up by the prep_params dictionary.
 
     Attributes
     ----------


### PR DESCRIPTION
# PR Description

- Adds the defaults 10s filter length
- Adds filter_kwargs parameter

closes #35 #18 

I dont know if this is what you have in mind...

I'm also a bit busy again ( new exams, deadlines approaching etc) but I managed advance this a bit.

What do you mean by (in #35) 

> And perhaps test whether that'd a good idea?

Originally clean line uses like 2-4 second windows with 50% overlap. 