### PR TITLE
added noisy_channels_before and _after interpolation attributes

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -33,6 +33,8 @@ Current
 
 Changelog
 ~~~~~~~~~
+- Added two attributes :attribute:`PrepPipeline.noisy_channels_before_interpolation` and :attribute:`PrepPipeline.noisy_channels_after_interpolation` which have the detailed output of each noisy criteria, by `Yorguin Mantilla`_ (`#45 <https://github.com/sappelhoff/pyprep/pull/45>`_)
+- Added two keys to the :attribute:`PrepPipeline.noisy_channels_original` dictionary: ``bad_by_dropout`` and ``bad_by_SNR``, by `Yorguin Mantilla`_ (`#45 <https://github.com/sappelhoff/pyprep/pull/45>`_)
 - Changed RANSAC chunking logic to reduce max memory use and prefer equal chunk sizes where possible, by `Austin Hurst`_ (`#44 <https://github.com/sappelhoff/pyprep/pull/44>`_)
 
 Bug
@@ -41,8 +43,6 @@ Bug
 
 API
 ~~~
-- Added two attributes to ``PrepPipeline``: ``noisy_channels_before_interpolation`` and ``noisy_channels_after_interpolation`` which have the detailed output of each noisy criteria, by `Yorguin Mantilla`_ (`#45 <https://github.com/sappelhoff/pyprep/pull/45>`_)
-- Added two keys to the ``PrepPipeline.noisy_channels_original`` dictionary: ``bad_by_dropout`` and ``bad_by_SNR``, by `Yorguin Mantilla`_ (`#45 <https://github.com/sappelhoff/pyprep/pull/45>`_)
 - The permissible parameters for the following methods were removed and/or reordered: :meth:`NoisyChannels.ransac_correlations`, :meth:`NoisyChannels.run_ransac`, and :meth:`NoisyChannels.get_ransac_pred` methods, by `Austin Hurst`_ and `Yorguin Mantilla`_ (`#43 <https://github.com/sappelhoff/pyprep/pull/43>`_)
 
 .. _changes_0_3_1:

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -33,6 +33,7 @@ Current
 
 Changelog
 ~~~~~~~~~
+- Added ``noisy_channels_before_interpolation`` and ``noisy_channels_after_interpolation`` attributes to ``PrepPipeline`` which have the detailed output of each noisy criteria, by `Yorguin Mantilla`_ (`#45 <https://github.com/sappelhoff/pyprep/pull/45>`_)
 - Changed RANSAC chunking logic to reduce max memory use and prefer equal chunk sizes where possible, by `Austin Hurst`_ (`#44 <https://github.com/sappelhoff/pyprep/pull/44>`_)
 
 Bug

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -42,6 +42,8 @@ Bug
 
 API
 ~~~
+- Added two attributes to ``PrepPipeline``: ``noisy_channels_before_interpolation`` and ``noisy_channels_after_interpolation``, by `Yorguin Mantilla`_ (`#45 <https://github.com/sappelhoff/pyprep/pull/45>`_)
+- Added two keys to the ``PrepPipeline.noisy_channels_original`` dictionary: ``bad_by_dropout`` and ``bad_by_SNR``, by `Yorguin Mantilla`_ (`#45 <https://github.com/sappelhoff/pyprep/pull/45>`_)
 - The permissible parameters for the following methods were removed and/or reordered: :meth:`NoisyChannels.ransac_correlations`, :meth:`NoisyChannels.run_ransac`, and :meth:`NoisyChannels.get_ransac_pred` methods, by `Austin Hurst`_ and `Yorguin Mantilla`_ (`#43 <https://github.com/sappelhoff/pyprep/pull/43>`_)
 
 .. _changes_0_3_1:

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -33,8 +33,8 @@ Current
 
 Changelog
 ~~~~~~~~~
-- Added two attributes :attribute:`PrepPipeline.noisy_channels_before_interpolation` and :attribute:`PrepPipeline.noisy_channels_after_interpolation` which have the detailed output of each noisy criteria, by `Yorguin Mantilla`_ (`#45 <https://github.com/sappelhoff/pyprep/pull/45>`_)
-- Added two keys to the :attribute:`PrepPipeline.noisy_channels_original` dictionary: ``bad_by_dropout`` and ``bad_by_SNR``, by `Yorguin Mantilla`_ (`#45 <https://github.com/sappelhoff/pyprep/pull/45>`_)
+- Added two attributes :attr:`PrepPipeline.noisy_channels_before_interpolation` and :attr:`PrepPipeline.noisy_channels_after_interpolation` which have the detailed output of each noisy criteria, by `Yorguin Mantilla`_ (`#45 <https://github.com/sappelhoff/pyprep/pull/45>`_)
+- Added two keys to the :attr:`PrepPipeline.noisy_channels_original` dictionary: ``bad_by_dropout`` and ``bad_by_SNR``, by `Yorguin Mantilla`_ (`#45 <https://github.com/sappelhoff/pyprep/pull/45>`_)
 - Changed RANSAC chunking logic to reduce max memory use and prefer equal chunk sizes where possible, by `Austin Hurst`_ (`#44 <https://github.com/sappelhoff/pyprep/pull/44>`_)
 
 Bug

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -33,7 +33,6 @@ Current
 
 Changelog
 ~~~~~~~~~
-- Added ``noisy_channels_before_interpolation`` and ``noisy_channels_after_interpolation`` attributes to ``PrepPipeline`` which have the detailed output of each noisy criteria, by `Yorguin Mantilla`_ (`#45 <https://github.com/sappelhoff/pyprep/pull/45>`_)
 - Changed RANSAC chunking logic to reduce max memory use and prefer equal chunk sizes where possible, by `Austin Hurst`_ (`#44 <https://github.com/sappelhoff/pyprep/pull/44>`_)
 
 Bug
@@ -42,7 +41,7 @@ Bug
 
 API
 ~~~
-- Added two attributes to ``PrepPipeline``: ``noisy_channels_before_interpolation`` and ``noisy_channels_after_interpolation``, by `Yorguin Mantilla`_ (`#45 <https://github.com/sappelhoff/pyprep/pull/45>`_)
+- Added two attributes to ``PrepPipeline``: ``noisy_channels_before_interpolation`` and ``noisy_channels_after_interpolation`` which have the detailed output of each noisy criteria, by `Yorguin Mantilla`_ (`#45 <https://github.com/sappelhoff/pyprep/pull/45>`_)
 - Added two keys to the ``PrepPipeline.noisy_channels_original`` dictionary: ``bad_by_dropout`` and ``bad_by_SNR``, by `Yorguin Mantilla`_ (`#45 <https://github.com/sappelhoff/pyprep/pull/45>`_)
 - The permissible parameters for the following methods were removed and/or reordered: :meth:`NoisyChannels.ransac_correlations`, :meth:`NoisyChannels.run_ransac`, and :meth:`NoisyChannels.get_ransac_pred` methods, by `Austin Hurst`_ and `Yorguin Mantilla`_ (`#43 <https://github.com/sappelhoff/pyprep/pull/43>`_)
 

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -518,6 +518,8 @@ class NoisyChannels:
                 if len(chunk_sizes):
                     chunk_size = chunk_sizes.pop()
                 else:
+                    # Can't test this branch since the '1 channel at a time' case
+                    # was already verified before
                     raise MemoryError(
                         "Not even doing 1 channel at a time the data fits in ram..."
                         "You could downsample the data or reduce the number of requ"

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -518,8 +518,6 @@ class NoisyChannels:
                 if len(chunk_sizes):
                     chunk_size = chunk_sizes.pop()
                 else:
-                    # Can't test this branch since the '1 channel at a time' case
-                    # was already verified before
                     raise MemoryError(
                         "Not even doing 1 channel at a time the data fits in ram..."
                         "You could downsample the data or reduce the number of requ"

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -517,7 +517,7 @@ class NoisyChannels:
             except MemoryError:
                 if len(chunk_sizes):
                     chunk_size = chunk_sizes.pop()
-                else:
+                else:  # pragma: no cover
                     raise MemoryError(
                         "Not even doing 1 channel at a time the data fits in ram..."
                         "You could downsample the data or reduce the number of requ"

--- a/pyprep/prep_pipeline.py
+++ b/pyprep/prep_pipeline.py
@@ -61,8 +61,12 @@ class PrepPipeline:
     raw_non_eeg : mne.raw | None
         The non-eeg part of the data. It is not processed when calling
         the fit method. If the input was only EEG it will be None.
-    noisy_channels_original : list
-        bad channels before robust reference
+    noisy_channels_original : dictionary
+        detailed bad channels in each criteria before robust reference
+    noisy_channels_before_interpolation : dictionary
+        detailed bad channels in each criteria just before interpolation
+    noisy_channels_after_interpolation : dictionary
+        detailed bad channels in each criteria just after interpolation
     bad_before_interpolation : list
         bad channels after robust reference but before interpolation
     EEG_before_interpolation : ndarray
@@ -182,6 +186,12 @@ class PrepPipeline:
         reference.perform_reference()
         self.raw_eeg = reference.raw
         self.noisy_channels_original = reference.noisy_channels_original
+        self.noisy_channels_before_interpolation = (
+            reference.noisy_channels_before_interpolation
+        )
+        self.noisy_channels_after_interpolation = (
+            reference.noisy_channels_after_interpolation
+        )
         self.bad_before_interpolation = reference.bad_before_interpolation
         self.EEG_before_interpolation = reference.EEG_before_interpolation
         self.reference_before_interpolation = reference.reference_signal

--- a/pyprep/prep_pipeline.py
+++ b/pyprep/prep_pipeline.py
@@ -61,12 +61,12 @@ class PrepPipeline:
     raw_non_eeg : mne.raw | None
         The non-eeg part of the data. It is not processed when calling
         the fit method. If the input was only EEG it will be None.
-    noisy_channels_original : dictionary
-        detailed bad channels in each criteria before robust reference
-    noisy_channels_before_interpolation : dictionary
-        detailed bad channels in each criteria just before interpolation
-    noisy_channels_after_interpolation : dictionary
-        detailed bad channels in each criteria just after interpolation
+    noisy_channels_original : dict
+       Detailed bad channels in each criteria before robust reference.
+    noisy_channels_before_interpolation : dict
+        Detailed bad channels in each criteria just before interpolation.
+    noisy_channels_after_interpolation : dict
+        Detailed bad channels in each criteria just after interpolation.
     bad_before_interpolation : list
         bad channels after robust reference but before interpolation
     EEG_before_interpolation : ndarray

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -97,6 +97,17 @@ class Reference:
         # Record Noisy channels and EEG before interpolation
         self.bad_before_interpolation = noisy_detector.get_bads(verbose=True)
         self.EEG_before_interpolation = self.EEG.copy()
+        self.noisy_channels_before_interpolation = {
+            "bad_by_nan": noisy_detector.bad_by_nan,
+            "bad_by_flat": noisy_detector.bad_by_flat,
+            "bad_by_deviation": noisy_detector.bad_by_deviation,
+            "bad_by_hf_noise": noisy_detector.bad_by_hf_noise,
+            "bad_by_correlation": noisy_detector.bad_by_correlation,
+            "bad_by_SNR": noisy_detector.bad_by_SNR,
+            "bad_by_dropout": noisy_detector.bad_by_dropout,
+            "bad_by_ransac": noisy_detector.bad_by_ransac,
+            "bad_all": noisy_detector.get_bads(),
+        }
 
         bad_channels = _union(self.bad_before_interpolation, self.unusable_channels)
         self.raw.info["bads"] = bad_channels
@@ -119,6 +130,18 @@ class Reference:
         noisy_detector.find_all_bads(ransac=self.ransac)
         self.still_noisy_channels = noisy_detector.get_bads()
         self.raw.info["bads"] = self.still_noisy_channels
+        self.noisy_channels_after_interpolation = {
+            "bad_by_nan": noisy_detector.bad_by_nan,
+            "bad_by_flat": noisy_detector.bad_by_flat,
+            "bad_by_deviation": noisy_detector.bad_by_deviation,
+            "bad_by_hf_noise": noisy_detector.bad_by_hf_noise,
+            "bad_by_correlation": noisy_detector.bad_by_correlation,
+            "bad_by_SNR": noisy_detector.bad_by_SNR,
+            "bad_by_dropout": noisy_detector.bad_by_dropout,
+            "bad_by_ransac": noisy_detector.bad_by_ransac,
+            "bad_all": noisy_detector.get_bads(),
+        }
+
         return self
 
     def robust_reference(self):
@@ -155,9 +178,12 @@ class Reference:
             "bad_by_deviation": noisy_detector.bad_by_deviation,
             "bad_by_hf_noise": noisy_detector.bad_by_hf_noise,
             "bad_by_correlation": noisy_detector.bad_by_correlation,
+            "bad_by_SNR": noisy_detector.bad_by_SNR,
+            "bad_by_dropout": noisy_detector.bad_by_dropout,
             "bad_by_ransac": noisy_detector.bad_by_ransac,
             "bad_all": noisy_detector.get_bads(),
         }
+
         self.noisy_channels = self.noisy_channels_original.copy()
         logger.info("Bad channels: {}".format(self.noisy_channels))
 

--- a/tests/test_find_noisy_channels.py
+++ b/tests/test_find_noisy_channels.py
@@ -145,3 +145,15 @@ def test_findnoisychannels(raw, montage):
     n_samples = 35.5
     with pytest.raises(TypeError):
         nd.find_bad_by_ransac(n_samples=n_samples)
+
+    # Test IOError when not enough channels for ransac predictions
+    raw_tmp = raw.copy()
+    # Make flat all channels except 2
+    num_bad_channels = raw._data.shape[0] - 2
+    raw_tmp._data[0:num_bad_channels, :] = np.zeros_like(
+        raw_tmp._data[0:num_bad_channels, :]
+    )
+    nd = NoisyChannels(raw_tmp, random_state=rng)
+    nd.find_all_bads(ransac=False)
+    with pytest.raises(IOError):
+        nd.find_bad_by_ransac()

--- a/tests/test_prep_pipeline.py
+++ b/tests/test_prep_pipeline.py
@@ -32,7 +32,7 @@ def test_prep_pipeline(raw, montage):
     EEG_raw_diff = EEG_raw - EEG_raw_matlab
     # EEG_raw_mse = (EEG_raw_diff / EEG_raw_max ** 2).mean(axis=None)
 
-    fig, axs = plt.subplots(5, 3, "all")
+    fig, axs = plt.subplots(5, 3, sharex="all")
     plt.setp(fig, facecolor=[1, 1, 1])
     fig.suptitle("Python versus Matlab PREP results", fontsize=16)
 


### PR DESCRIPTION
Thanks for contributing.
If this is your first time, please make sure to read the [contributing guideline][contrib-guideline].

# PR Description

This PR adds two attributes to PrepPipeline:

- noisy_channels_before_interpolation
- noisy_channels_after_interpolation

Which are dictionaries with the detailed results of bad channels identified by each criteria, that is:

```python
noisy_channels_x_x = {
            "bad_by_nan": noisy_detector.bad_by_nan,
            "bad_by_flat": noisy_detector.bad_by_flat,
            "bad_by_deviation": noisy_detector.bad_by_deviation,
            "bad_by_hf_noise": noisy_detector.bad_by_hf_noise,
            "bad_by_correlation": noisy_detector.bad_by_correlation,
            "bad_by_SNR": noisy_detector.bad_by_SNR,
            "bad_by_dropout": noisy_detector.bad_by_dropout,
            "bad_by_ransac": noisy_detector.bad_by_ransac,
            "bad_all": noisy_detector.get_bads(),
        }
```
closes #20 

Also added two keys to ``PrepPipeline.noisy_channels_original``:
- bad_by_dropout
- bad_by_SNR

A test for the IOError when not enough channels to make predictions in ransac was implemented.

# Merge Checklist

To merge your PR we need to first take the following points into account:

- [ ] the PR has been reviewed and all comments are resolved
- [ ] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [whats_new.rst][whats-new-file]

[contrib-guideline]: https://github.com/sappelhoff/pyprep/blob/master/.github/CONTRIBUTING.md

[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration

[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface

[whats-new-file]: https://github.com/sappelhoff/pyprep/blob/master/docs/whats_new.rst
