### PR TITLE
Changed bad-by-flat threshold to match MATLAB PREP

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -41,6 +41,7 @@ Changelog
 Bug
 ~~~
 - Fixed RANSAC to give consistent results with a fixed seed across different chunk sizes, by `Austin Hurst`_ and `Yorguin Mantilla`_ (:gh:`43`)
+- Fixed "bad channel by flat" threshold in :meth:`NoisyChannels.find_bad_by_nan_flat` to be consistent with MATLAB PREP, by `Austin Hurst`_ (:gh:`60`)
 
 API
 ~~~

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -154,12 +154,13 @@ class NoisyChannels:
         nan_channel_mask = [False] * self.original_dimensions[0]
         no_signal_channel_mask = [False] * self.original_dimensions[0]
 
+        flat_threshold = 1e-15  # corresponds to 10e-10 µV in MATLAB PREP
         for i in range(0, self.original_dimensions[0]):
             nan_channel_mask[i] = np.sum(np.isnan(self.EEGData[i, :])) > 0
         for i in range(0, self.original_dimensions[0]):
             no_signal_channel_mask[i] = (
-                robust.mad(self.EEGData[i, :], c=1) < 1e-10
-                or np.std(self.EEGData[i, :]) < 1e-10
+                robust.mad(self.EEGData[i, :], c=1) < flat_threshold
+                or np.std(self.EEGData[i, :]) < flat_threshold
             )
         nan_channels = self.channels_interpolate[nan_channel_mask]
         flat_channels = self.channels_interpolate[no_signal_channel_mask]

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -154,13 +154,13 @@ class NoisyChannels:
         nan_channel_mask = [False] * self.original_dimensions[0]
         no_signal_channel_mask = [False] * self.original_dimensions[0]
 
-        flat_threshold = 1e-15  # corresponds to 10e-10 µV in MATLAB PREP
+        FLAT_THRESHOLD = 1e-15  # corresponds to 10e-10 µV in MATLAB PREP
         for i in range(0, self.original_dimensions[0]):
             nan_channel_mask[i] = np.sum(np.isnan(self.EEGData[i, :])) > 0
         for i in range(0, self.original_dimensions[0]):
             no_signal_channel_mask[i] = (
-                robust.mad(self.EEGData[i, :], c=1) < flat_threshold
-                or np.std(self.EEGData[i, :]) < flat_threshold
+                robust.mad(self.EEGData[i, :], c=1) < FLAT_THRESHOLD
+                or np.std(self.EEGData[i, :]) < FLAT_THRESHOLD
             )
         nan_channels = self.channels_interpolate[nan_channel_mask]
         flat_channels = self.channels_interpolate[no_signal_channel_mask]


### PR DESCRIPTION
# PR Description

Closes #59.

Basically, this PR just corrects for the fact that EEGLAB's internal units are in micro volts whereas MNE's internal units are in volts.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [ ] the PR has been reviewed and all comments are resolved
- [ ] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [whats_new.rst][whats-new-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[whats-new-file]: https://github.com/sappelhoff/pyprep/blob/master/docs/whats_new.rst
