### PR TITLE
Retain HF noise channels during RANSAC when not bad by any other metric

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -38,6 +38,7 @@ Changelog
 - Added two keys to the :attr:`PrepPipeline.noisy_channels_original <prep_pipeline.PrepPipeline>` dictionary: ``bad_by_dropout`` and ``bad_by_SNR``, by `Yorguin Mantilla`_ (:gh:`45`)
 - Changed RANSAC chunking logic to reduce max memory use and prefer equal chunk sizes where possible, by `Austin Hurst`_ (:gh:`44`)
 - Changed RANSAC's random channel sampling code to produce the same results as MATLAB PREP for the same random seed, additionally changing the default RANSAC sample size from 25% of all *good* channels (e.g. 15 for a 64-channel dataset with 4 bad channels) to 25% of *all* channels (e.g. 16 for the same dataset), by `Austin Hurst`_ (:gh:`62`)
+- Changed RANSAC so that "bad by high-frequency noise" channels are retained when making channel predictions (provided they aren't flagged as bad by any other metric), matching MATLAB PREP behaviour, by `Austin Hurst`_ (:gh:`64`)
 
 Bug
 ~~~

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -421,13 +421,18 @@ class NoisyChannels:
             (2017). Autoreject: Automated Artifact Rejection for MEG and EEG
             Data. NeuroImage, 159, 417-429
         """
+        exclude_from_ransac = (
+            self.bad_by_correlation +
+            self.bad_by_deviation +
+            self.bad_by_dropout
+        )
         self.bad_by_ransac, _ = find_bad_by_ransac(
             self.EEGData,
             self.sample_rate,
             self.signal_len,
             self.ch_names_new,
             self.raw_mne._get_channel_positions(),
-            self.get_bads(),
+            exclude_from_ransac,
             n_samples,
             fraction_good,
             corr_thresh,

--- a/tests/test_find_noisy_channels.py
+++ b/tests/test_find_noisy_channels.py
@@ -153,7 +153,7 @@ def test_findnoisychannels(raw, montage):
     # Make 80% of channels bad
     num_bad_channels = int(raw._data.shape[0] * 0.8)
     bad_channels = raw.info["ch_names"][0:num_bad_channels]
-    nd.bad_by_hf_noise = bad_channels
+    nd.bad_by_deviation = bad_channels
     with pytest.raises(IOError):
         nd.find_bad_by_ransac()
 


### PR DESCRIPTION
<!--Thanks for contributing-->
<!--If this is your first time, please make sure to read the contributing guideline-->
<!--https://github.com/sappelhoff/pyprep/blob/master/.github/CONTRIBUTING.md-->

# PR Description

Closes #63. This PR modifies NoisyChannels so that channels bad by high-frequency noise (and only by HF-noise) are included in RANSAC predictions, as they are in MATLAB PREP.

The rationale for this (other than lining up more closely with MatPREP's internal logic) is that RANSAC uses a copy of the data that's been lowpass-filtered at 50Hz anyway, so high-frequency noise isn't necessarily automatic grounds for exclusion.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [x] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [whats_new.rst][whats-new-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[whats-new-file]: https://github.com/sappelhoff/pyprep/blob/master/docs/whats_new.rst
