### PR TITLE
Add window-wise RANSAC to reduce RAM requirements

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -41,6 +41,8 @@ Changelog
 - Changed RANSAC so that "bad by high-frequency noise" channels are retained when making channel predictions (provided they aren't flagged as bad by any other metric), matching MATLAB PREP behaviour, by `Austin Hurst`_ (:gh:`64`)
 - Added a new flag ``matlab_strict`` to :class:`~pyprep.PrepPipeline`, :class:`~pyprep.Reference`, :class:`~pyprep.NoisyChannels`, and :func:`~pyprep.ransac.find_bad_by_ransac` for optionally matching MATLAB PREP's internal math as closely as possible, overriding areas where PyPREP attempts to improve on the original, by `Austin Hurst`_ (:gh:`70`)
 - Added a ``matlab_strict`` method for high-pass trend removal, exactly matching MATLAB PREP's values if ``matlab_strict`` is enabled, by `Austin Hurst`_ (:gh:`71`)
+- Added a window-wise implementaion of RANSAC and made it the default method, reducing the typical RAM demands of robust re-referencing considerably, by `Austin Hurst`_ (:gh:`66`)
+- Added `max_chunk_size` parameter for specifying the maximum chunk size to use for channel-wise RANSAC, allowing more control over PyPREP RAM usage, by `Austin Hurst`_ (:gh:`66`)
 
 Bug
 ~~~
@@ -55,6 +57,7 @@ API
 - The permissible parameters for the following methods were removed and/or reordered: `ransac._ransac_correlations`, `ransac._run_ransac`, and `ransac._get_ransac_pred` methods, by `Yorguin Mantilla`_ (:gh:`51`)
 - The following methods have been moved to a new module named :mod:`~pyprep.ransac` and are now private: `NoisyChannels.ransac_correlations`, `NoisyChannels.run_ransac`, and `NoisyChannels.get_ransac_pred` methods, by `Yorguin Mantilla`_ (:gh:`51`)
 - The permissible parameters for the following methods were removed and/or reordered: `NoisyChannels.ransac_correlations`, `NoisyChannels.run_ransac`, and `NoisyChannels.get_ransac_pred` methods, by `Austin Hurst`_ and `Yorguin Mantilla`_ (:gh:`43`)
+- Changed the meaning of the argument `channel_wise` in :meth:`~pyprep.NoisyChannels.find_bad_by_ransac` to mean 'perform RANSAC across chunks of channels instead of window-wise', from its original meaning of 'perform channel-wise RANSAC one channel at a time', by `Austin Hurst`_ (:gh:`66`)
 
 
 .. _changes_0_3_1:

--- a/examples/run_ransac.py
+++ b/examples/run_ransac.py
@@ -74,14 +74,15 @@ nd = NoisyChannels(raw)
 nd2 = NoisyChannels(raw)
 
 ###############################################################################
-# Find all bad channels and print a summary
+# Find all bad channels using channel-wise RANSAC and print a summary
 start_time = perf_counter()
-nd.find_bad_by_ransac()
+nd.find_bad_by_ransac(channel_wise=True)
 print("--- %s seconds ---" % (perf_counter() - start_time))
 
-# Repeat RANSAC in a channel wise manner. This is slower but needs less memory.
+# Repeat channel-wise RANSAC using a single channel at a time. This is slower
+# but needs less memory.
 start_time = perf_counter()
-nd2.find_bad_by_ransac(channel_wise=True)
+nd2.find_bad_by_ransac(channel_wise=True, max_chunk_size=1)
 print("--- %s seconds ---" % (perf_counter() - start_time))
 
 ###############################################################################

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -479,6 +479,7 @@ class NoisyChannels:
             fraction_bad,
             corr_window_secs,
             channel_wise,
+            False,
             self.random_state,
             self.matlab_strict,
         )

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -144,22 +144,42 @@ class NoisyChannels:
             )
         return bads
 
-    def find_all_bads(self, ransac=True):
+    def find_all_bads(self, ransac=True, channel_wise=False, max_chunk_size=None):
         """Call all the functions to detect bad channels.
 
         This function calls all the bad-channel detecting functions.
 
         Parameters
         ----------
-        ransac : bool
-            To detect channels by ransac or not.
+        ransac : bool, optional
+            Whether RANSAC should be for bad channel detection, in addition to
+            the other methods. RANSAC can detect bad channels that other methods
+            are unable to catch, but also slows down noisy channel detection
+            considerably. Defaults to ``True``.
+        channel_wise : bool, optional
+            Whether RANSAC should predict signals for whole chunks of channels
+            at once instead of predicting signals for each RANSAC window
+            individually. Channel-wise RANSAC generally has higher RAM demands
+            than window-wise RANSAC (especially if `max_chunk_size` is
+            ``None``), but can be faster on systems with lots of RAM to spare.
+            Has no effect if not using RANSAC. Defaults to ``False``.
+        max_chunk_size : {int, None}, optional
+            The maximum number of channels to predict at once during
+            channel-wise RANSAC. If ``None``, RANSAC will use the largest chunk
+            size that will fit into the available RAM, which may slow down
+            other programs on the host system. If using window-wise RANSAC
+            (the default) or not using RANSAC at all, this parameter has no
+            effect. Defaults to ``None``.
 
         """
         self.find_bad_by_nan_flat()
         self.find_bad_by_deviation()
         self.find_bad_by_SNR()
         if ransac:
-            self.find_bad_by_ransac()
+            self.find_bad_by_ransac(
+                channel_wise=channel_wise,
+                max_chunk_size=max_chunk_size
+            )
 
     def find_bad_by_nan_flat(self):
         """Detect channels that appear flat or have NaN values."""

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -152,17 +152,20 @@ class NoisyChannels:
         Parameters
         ----------
         ransac : bool, optional
-            Whether RANSAC should be for bad channel detection, in addition to
-            the other methods. RANSAC can detect bad channels that other methods
-            are unable to catch, but also slows down noisy channel detection
-            considerably. Defaults to ``True``.
+            Whether RANSAC should be used for bad channel detection, in addition
+            to the other methods. RANSAC can detect bad channels that other
+            methods are unable to catch, but also slows down noisy channel
+            detection considerably. Defaults to ``True``.
         channel_wise : bool, optional
-            Whether RANSAC should predict signals for whole chunks of channels
-            at once instead of predicting signals for each RANSAC window
-            individually. Channel-wise RANSAC generally has higher RAM demands
-            than window-wise RANSAC (especially if `max_chunk_size` is
-            ``None``), but can be faster on systems with lots of RAM to spare.
-            Has no effect if not using RANSAC. Defaults to ``False``.
+            Whether RANSAC should predict signals for chunks of channels over the
+            entire signal length ("channel-wise RANSAC", see `max_chunk_size`
+            parameter). If ``False``, RANSAC will instead predict signals for all
+            channels at once but over a number of smaller time windows instead of
+            over the entirem signal length ("window-wise RANSAC"). Channel-wise
+            RANSAC generally has higher RAM demands than window-wise RANSAC
+            (especially if `max_chunk_size` is ``None``), but can be faster on
+            systems with lots of RAM to spare. Has no effect if not using RANSAC.
+            Defaults to ``False``.
         max_chunk_size : {int, None}, optional
             The maximum number of channels to predict at once during
             channel-wise RANSAC. If ``None``, RANSAC will use the largest chunk
@@ -468,12 +471,14 @@ class NoisyChannels:
             The duration (in seconds) of each RANSAC correlation window. Defaults
             to 5 seconds.
         channel_wise : bool, optional
-            Whether RANSAC should predict signals for whole chunks of channels
-            at once instead of predicting signals for each RANSAC window
-            individually. Channel-wise RANSAC generally has higher RAM demands
-            than window-wise RANSAC (especially if `max_chunk_size` is
-            ``None``), but can be faster on systems with lots of RAM to spare.
-            Defaults to ``False``.
+            Whether RANSAC should predict signals for chunks of channels over the
+            entire signal length ("channel-wise RANSAC", see `max_chunk_size`
+            parameter). If ``False``, RANSAC will instead predict signals for all
+            channels at once but over a number of smaller time windows instead of
+            over the entirem signal length ("window-wise RANSAC"). Channel-wise
+            RANSAC generally has higher RAM demands than window-wise RANSAC
+            (especially if `max_chunk_size` is ``None``), but can be faster on
+            systems with lots of RAM to spare. Defaults to ``False``.
         max_chunk_size : {int, None}, optional
             The maximum number of channels to predict at once during
             channel-wise RANSAC. If ``None``, RANSAC will use the largest chunk

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -161,7 +161,7 @@ class NoisyChannels:
             entire signal length ("channel-wise RANSAC", see `max_chunk_size`
             parameter). If ``False``, RANSAC will instead predict signals for all
             channels at once but over a number of smaller time windows instead of
-            over the entirem signal length ("window-wise RANSAC"). Channel-wise
+            over the entire signal length ("window-wise RANSAC"). Channel-wise
             RANSAC generally has higher RAM demands than window-wise RANSAC
             (especially if `max_chunk_size` is ``None``), but can be faster on
             systems with lots of RAM to spare. Has no effect if not using RANSAC.
@@ -475,7 +475,7 @@ class NoisyChannels:
             entire signal length ("channel-wise RANSAC", see `max_chunk_size`
             parameter). If ``False``, RANSAC will instead predict signals for all
             channels at once but over a number of smaller time windows instead of
-            over the entirem signal length ("window-wise RANSAC"). Channel-wise
+            over the entire signal length ("window-wise RANSAC"). Channel-wise
             RANSAC generally has higher RAM demands than window-wise RANSAC
             (especially if `max_chunk_size` is ``None``), but can be faster on
             systems with lots of RAM to spare. Defaults to ``False``.

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -409,6 +409,7 @@ class NoisyChannels:
         fraction_bad=0.4,
         corr_window_secs=5.0,
         channel_wise=False,
+        max_chunk_size=None,
     ):
         """Detect channels that are not predicted well by other channels.
 
@@ -447,10 +448,18 @@ class NoisyChannels:
             The duration (in seconds) of each RANSAC correlation window. Defaults
             to 5 seconds.
         channel_wise : bool, optional
-            Whether RANSAC should be performed one channel at a time (lower RAM
-            demands) or in chunks of as many channels as can fit into the
-            currently available RAM (faster). Defaults to ``False`` (i.e., using
-            the faster method).
+            Whether RANSAC should predict signals for whole chunks of channels
+            at once instead of predicting signals for each RANSAC window
+            individually. Channel-wise RANSAC generally has higher RAM demands
+            than window-wise RANSAC (especially if `max_chunk_size` is
+            ``None``), but can be faster on systems with lots of RAM to spare.
+            Defaults to ``False``.
+        max_chunk_size : {int, None}, optional
+            The maximum number of channels to predict at once during
+            channel-wise RANSAC. If ``None``, RANSAC will use the largest chunk
+            size that will fit into the available RAM, which may slow down
+            other programs on the host system. If using window-wise RANSAC
+            (the default), this parameter has no effect. Defaults to ``None``.
 
         References
         ----------
@@ -479,7 +488,7 @@ class NoisyChannels:
             fraction_bad,
             corr_window_secs,
             channel_wise,
-            False,
+            max_chunk_size,
             self.random_state,
             self.matlab_strict,
         )

--- a/pyprep/prep_pipeline.py
+++ b/pyprep/prep_pipeline.py
@@ -43,7 +43,7 @@ class PrepPipeline:
         entire signal length ("channel-wise RANSAC", see `max_chunk_size`
         parameter). If ``False``, RANSAC will instead predict signals for all
         channels at once but over a number of smaller time windows instead of
-        over the entirem signal length ("window-wise RANSAC"). Channel-wise
+        over the entire signal length ("window-wise RANSAC"). Channel-wise
         RANSAC generally has higher RAM demands than window-wise RANSAC
         (especially if `max_chunk_size` is ``None``), but can be faster on
         systems with lots of RAM to spare. Has no effect if not using RANSAC.

--- a/pyprep/prep_pipeline.py
+++ b/pyprep/prep_pipeline.py
@@ -39,12 +39,15 @@ class PrepPipeline:
         Whether or not to use RANSAC for noisy channel detection in addition to
         the other methods in :class:`~pyprep.NoisyChannels`. Defaults to True.
     channel_wise : bool, optional
-        Whether RANSAC should predict signals for whole chunks of channels at
-        once instead of predicting signals for each RANSAC window
-        individually. Channel-wise RANSAC generally has higher RAM demands than
-        window-wise RANSAC (especially if `max_chunk_size` is ``None``), but can
-        be faster on systems with lots of RAM to spare.nHas no effect if not
-        using RANSAC. Defaults to ``False``.
+        Whether RANSAC should predict signals for chunks of channels over the
+        entire signal length ("channel-wise RANSAC", see `max_chunk_size`
+        parameter). If ``False``, RANSAC will instead predict signals for all
+        channels at once but over a number of smaller time windows instead of
+        over the entirem signal length ("window-wise RANSAC"). Channel-wise
+        RANSAC generally has higher RAM demands than window-wise RANSAC
+        (especially if `max_chunk_size` is ``None``), but can be faster on
+        systems with lots of RAM to spare. Has no effect if not using RANSAC.
+        Defaults to ``False``.
     max_chunk_size : {int, None}, optional
         The maximum number of channels to predict at once during channel-wise
         RANSAC. If ``None``, RANSAC will use the largest chunk size that will

--- a/pyprep/ransac.py
+++ b/pyprep/ransac.py
@@ -76,7 +76,7 @@ def find_bad_by_ransac(
         entire signal length ("channel-wise RANSAC", see `max_chunk_size`
         parameter). If ``False``, RANSAC will instead predict signals for all
         channels at once but over a number of smaller time windows instead of
-        over the entirem signal length ("window-wise RANSAC"). Channel-wise
+        over the entire signal length ("window-wise RANSAC"). Channel-wise
         RANSAC generally has higher RAM demands than window-wise RANSAC
         (especially if `max_chunk_size` is ``None``), but can be faster on
         systems with lots of RAM to spare. Defaults to ``False``.

--- a/pyprep/ransac.py
+++ b/pyprep/ransac.py
@@ -72,11 +72,14 @@ def find_bad_by_ransac(
         The duration (in seconds) of each RANSAC correlation window. Defaults to
         5 seconds.
     channel_wise : bool, optional
-        Whether RANSAC should predict signals for whole chunks of channels at
-        once instead of predicting signals for each RANSAC window individually.
-        Channel-wise RANSAC generally has higher RAM demands than window-wise
-        RANSAC (especially if `max_chunk_size` is ``None``), but can be faster
-        on systems with lots of RAM to spare. Defaults to ``False``.
+        Whether RANSAC should predict signals for chunks of channels over the
+        entire signal length ("channel-wise RANSAC", see `max_chunk_size`
+        parameter). If ``False``, RANSAC will instead predict signals for all
+        channels at once but over a number of smaller time windows instead of
+        over the entirem signal length ("window-wise RANSAC"). Channel-wise
+        RANSAC generally has higher RAM demands than window-wise RANSAC
+        (especially if `max_chunk_size` is ``None``), but can be faster on
+        systems with lots of RAM to spare. Defaults to ``False``.
     max_chunk_size : {int, None}, optional
         The maximum number of channels to predict at once during channel-wise
         RANSAC. If ``None``, RANSAC will use the largest chunk size that will

--- a/pyprep/ransac.py
+++ b/pyprep/ransac.py
@@ -5,7 +5,8 @@ from mne.channels.interpolation import _make_interpolation_matrix
 from mne.utils import check_random_state
 
 from pyprep.utils import (
-    split_list, verify_free_ram, _get_random_subset, _mat_round, _correlate_arrays
+    _get_random_subset, _mat_round, _correlate_arrays, print_progress,
+    split_list, verify_free_ram
 )
 
 
@@ -314,6 +315,9 @@ def _ransac_by_window(data, interpolation_mats, win_size, win_count, matlab_stri
     correlations = np.ones((win_count, ch_count))
 
     for window in range(win_count):
+
+        # Print RANSAC progress in 10% increments
+        print_progress(window + 1, win_count, every=0.1)
 
         # Get the current window of EEG data
         start = window * win_size

--- a/pyprep/ransac.py
+++ b/pyprep/ransac.py
@@ -364,7 +364,7 @@ def _predict_median_signals(window, interpolation_mats, matlab_strict=False):
     -----
     In MATLAB PREP, the median signal is calculated by sorting the different
     predictions for each EEG sample/channel from low to high and then taking the value
-    at the middle index (as calculated by `int(n_ransac_samples / 2.0)`) for each.
+    at the middle index (as calculated by ``int(n_ransac_samples / 2.0)``) for each.
     Because this logic only returns the correct result for odd numbers of samples, the
     current function will instead return the true median signal across predictions
     unless strict MATLAB equivalence is requested.

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -33,12 +33,15 @@ class Reference:
         Whether or not to use RANSAC for noisy channel detection in addition to
         the other methods in :class:`~pyprep.NoisyChannels`. Defaults to True.
     channel_wise : bool, optional
-        Whether RANSAC should predict signals for whole chunks of channels at
-        once instead of predicting signals for each RANSAC window
-        individually. Channel-wise RANSAC generally has higher RAM demands than
-        window-wise RANSAC (especially if `max_chunk_size` is ``None``), but can
-        be faster on systems with lots of RAM to spare.nHas no effect if not
-        using RANSAC. Defaults to ``False``.
+        Whether RANSAC should predict signals for chunks of channels over the
+        entire signal length ("channel-wise RANSAC", see `max_chunk_size`
+        parameter). If ``False``, RANSAC will instead predict signals for all
+        channels at once but over a number of smaller time windows instead of
+        over the entire signal length ("window-wise RANSAC"). Channel-wise
+        RANSAC generally has higher RAM demands than window-wise RANSAC
+        (especially if `max_chunk_size` is ``None``), but can be faster on
+        systems with lots of RAM to spare. Has no effect if not using RANSAC.
+        Defaults to ``False``.
     max_chunk_size : {int, None}, optional
         The maximum number of channels to predict at once during channel-wise
         RANSAC. If ``None``, RANSAC will use the largest chunk size that will

--- a/pyprep/utils.py
+++ b/pyprep/utils.py
@@ -362,6 +362,44 @@ def split_list(mylist, chunk_size):
     ]
 
 
+def print_progress(current, end, start=None, stepsize=1, every=0.1):
+    """Print the current progress in a loop.
+
+    Parameters
+    ----------
+    current: {int, float}
+        The index or numeric value of the current position in the loop.
+    end: {int, float}
+        The final index or numeric value in the loop.
+    start: {int, float, None}, optional
+        The first index or numeric value in the loop. If ``None``, the start
+        index will assumed to be `stepsize` (i.e., 3 if `stepsize` is 3).
+        Defaults to ``None``.
+    stepsize: {int, float}, optional
+        The fixed amount by which `current` increases every iteration of the
+        loop. Defaults to ``1``.
+    every: float, optional
+        The frequency with which to print progress updates during the loop,
+        as a proportion between 0 and 1, exclusive. Defaults to ``0.1``, which
+        prints a progress update after every 10%.
+
+    """
+    start = stepsize if not start else start
+    end = end - start + 1
+    current = current - start + 1
+
+    if current == 1:
+        print("Progress:", end=" ", flush=True)
+    elif current == end:
+        print("100%")
+    elif current > 0:
+        progress = float(current) / end
+        last = float(current - stepsize) / end
+        if int(progress / every) > int(last / every):
+            pct = int(progress / every) * every * 100
+            print("{0}%...".format(int(pct)), end=" ", flush=True)
+
+
 def make_random_mne_object(
     ch_names,
     ch_types,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from pyprep.utils import (
     _mat_round, _mat_quantile, _mat_iqr, _get_random_subset, _correlate_arrays,
-    _eeglab_create_highpass
+    _eeglab_create_highpass, print_progress
 )
 
 
@@ -114,3 +114,43 @@ def test_eeglab_create_highpass():
     expected_val = 0.9961
     actual_val = vals[len(vals) // 2]
     assert np.isclose(expected_val, actual_val, atol=0.001)
+
+
+def test_print_progress(capsys):
+    """Test the function for printing progress updates within a loop."""
+    # Test printing start value
+    print_progress(1, 20)
+    captured = capsys.readouterr()
+    assert captured.out == "Progress: "
+
+    # Test printing end values
+    iterations = 27
+    for i in range(iterations):
+        print_progress(i + 1, iterations, every=0.2)
+    captured = capsys.readouterr()
+    assert captured.out == "Progress: 20%... 40%... 60%... 80%... 100%\n"
+
+    # Test printing of updates at right times
+    iterations = 176
+    for i in range(iterations):
+        print_progress(i + 1, iterations)
+        if (i + 1) == 17:
+            captured = capsys.readouterr()
+            assert captured.out == "Progress: "
+        elif (i + 1) == 18:
+            captured = capsys.readouterr()
+            assert captured.out == "10%... "
+            break
+
+    # Test shifted start value
+    iterations = 25
+    start = 5
+    for i in range(start, iterations + 1):
+        print_progress(i, iterations, start=start)
+        if i == 6:
+            captured = capsys.readouterr()
+            assert captured.out == "Progress: "
+        elif i == 7:
+            captured = capsys.readouterr()
+            assert captured.out == "10%... "
+            break


### PR DESCRIPTION
<!--Thanks for contributing-->
<!--If this is your first time, please make sure to read the contributing guideline-->
<!--https://github.com/sappelhoff/pyprep/blob/master/.github/CONTRIBUTING.md-->

# PR Description

(Updated) This PR does a few things:

- Adds support for window-wise RANSAC and makes it the default method
- Reworks channel-wise RANSAC to use the same pre-generated interpolation matrices as window-wise, which speeds things up and reduces the amount of divergent/redundant code between methods
- Reworks/refactors the channel-wise RANSAC functions a fair bit to better match the function names, argument names, variable names, and docstrings of their window-wise equivalence, for easier comparison and maintainability
- Adds a progress-printing function for window-wise RANSAC
- Overhauls the RANSAC unit tests considerably, including the addition of explicit comparison of the window-wise/channel-wise correlation matrices for both regular and MATLAB-strict RANSAC to make sure we get identical results for the same seed between methods (and that MATLAB strict values differ from non-strict ones as expected).

### Currently Missing
- [x] Progress indicators for RANSAC
- [x] Proper API for `matlab_strict` mode (handled in earlier PR)
- [ ] Any sort of optimization/parallelization for additional speed (I have some ideas, but will save for a future PR since this one's already pretty big)
- [x] Any sort of memory checking or channel chunking support (added memory check at start)
- [x] A clear idea of what to do about MATLAB PREP's weird correlation function (handled in earlier PR)

### Other Notes
- For my test file (`sub_002/ses-01` from that open meditation dataset), window-wise RANSAC is about 36% slower than the existing RANSAC approach (192 vs 141 seconds). However, RAM usage during RANSAC is now much lower (maxed out at 2.85 GB), which is nice but also suggests that window-wise RANSAC could be improved to take better advantage of RAM on beefier systems.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [ ] the PR has been reviewed and all comments are resolved
- [ ] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [whats_new.rst][whats-new-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[whats-new-file]: https://github.com/sappelhoff/pyprep/blob/master/docs/whats_new.rst
