### PR TITLE
Retain detailed info about calculations during NoisyChannels

### DIFF
--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -65,7 +65,13 @@ class NoisyChannels:
         self.channels_interpolate = self.original_channels
 
         # Extra data for debugging
-        self._extra_info = {}
+        self._extra_info = {
+            'bad_by_deviation': {},
+            'bad_by_hf_noise': {},
+            'bad_by_correlation': {},
+            'bad_by_dropout': {},
+            'bad_by_ransac': {}
+        }
 
         # random_state
         self.random_state = check_random_state(random_state)
@@ -210,11 +216,11 @@ class NoisyChannels:
         deviation_channels = self.channels_interpolate[deviation_channel_mask]
         for i in range(0, len(deviation_channels)):
             self.bad_by_deviation.append(self.ch_names_original[deviation_channels[i]])
-        self._extra_info['bad_by_deviation'] = {
+        self._extra_info['bad_by_deviation'].update({
             'median_channel_deviation': channel_deviationMedian,
             'channel_deviation_sd': channel_deviationSD,
             'robust_channel_deviations': robust_channel_deviation
-        }
+        })
 
     def find_bad_by_hfnoise(self, HF_zscore_threshold=5.0):
         """Determine noise of channel through high frequency ratio.
@@ -270,11 +276,11 @@ class NoisyChannels:
         self.EEGData = np.transpose(EEG_filt)
         for i in range(0, len(HFNoise_channels)):
             self.bad_by_hf_noise.append(self.ch_names_original[HFNoise_channels[i]])
-        self._extra_info['bad_by_hf_noise'] = {
+        self._extra_info['bad_by_hf_noise'].update({
             'median_channel_noisiness': noisiness_median,
             'channel_noisiness_sd': noiseSD,
             'hf_noise_zscores': zscore_HFNoise
-        }
+        })
 
     def find_bad_by_correlation(
         self, correlation_secs=1.0, correlation_threshold=0.4, frac_bad=0.01

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -64,6 +64,9 @@ class NoisyChannels:
         self.ch_names_new = self.ch_names_original
         self.channels_interpolate = self.original_channels
 
+        # Extra data for debugging
+        self._extra_info = {}
+
         # random_state
         self.random_state = check_random_state(random_state)
 
@@ -207,6 +210,11 @@ class NoisyChannels:
         deviation_channels = self.channels_interpolate[deviation_channel_mask]
         for i in range(0, len(deviation_channels)):
             self.bad_by_deviation.append(self.ch_names_original[deviation_channels[i]])
+        self._extra_info['bad_by_deviation'] = {
+            'median_channel_deviation': channel_deviationMedian,
+            'channel_deviation_sd': channel_deviationSD,
+            'robust_channel_deviations': robust_channel_deviation
+        }
 
     def find_bad_by_hfnoise(self, HF_zscore_threshold=5.0):
         """Determine noise of channel through high frequency ratio.
@@ -262,6 +270,11 @@ class NoisyChannels:
         self.EEGData = np.transpose(EEG_filt)
         for i in range(0, len(HFNoise_channels)):
             self.bad_by_hf_noise.append(self.ch_names_original[HFNoise_channels[i]])
+        self._extra_info['bad_by_hf_noise'] = {
+            'median_channel_noisiness': noisiness_median,
+            'channel_noisiness_sd': noiseSD,
+            'hf_noise_zscores': zscore_HFNoise
+        }
 
     def find_bad_by_correlation(
         self, correlation_secs=1.0, correlation_threshold=0.4, frac_bad=0.01
@@ -358,6 +371,17 @@ class NoisyChannels:
         dropout_channels_idx = np.argwhere(fraction_BadDropOutWindows > frac_bad)
         dropout_channels_name = self.ch_names_original[dropout_channels_idx.astype(int)]
         self.bad_by_dropout = [i[0] for i in dropout_channels_name]
+        self._extra_info['bad_by_correlation'] = {
+            'max_correlations': maximum_correlations,
+            'median_max_correlations': np.median(maximum_correlations, axis=1),
+            'bad_window_fractions': fraction_BadCorrelationWindows
+        }
+        self._extra_info['bad_by_dropout'] = {
+            'dropouts': drop_out,
+            'bad_window_fractions': fraction_BadDropOutWindows
+        }
+        self._extra_info['bad_by_deviation']['channel_deviations'] = channel_deviations
+        self._extra_info['bad_by_hf_noise']['noise_levels'] = noiselevels
 
     def find_bad_by_SNR(self):
         """Determine the channels that fail both by correlation and HF noise."""
@@ -426,7 +450,7 @@ class NoisyChannels:
             self.bad_by_deviation +
             self.bad_by_dropout
         )
-        self.bad_by_ransac, _ = find_bad_by_ransac(
+        self.bad_by_ransac, ch_correlations = find_bad_by_ransac(
             self.EEGData,
             self.sample_rate,
             self.signal_len,
@@ -441,3 +465,7 @@ class NoisyChannels:
             channel_wise,
             self.random_state,
         )
+        self._extra_info['bad_by_ransac'] = {
+            'ransac_correlations': ch_correlations,
+            'bad_window_fractions': np.mean(ch_correlations < corr_thresh, axis=0)
+        }

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -57,6 +57,7 @@ class Reference:
         self.sfreq = self.raw.info["sfreq"]
         self.ransac = ransac
         self.random_state = check_random_state(random_state)
+        self._extra_info = {}
 
     def perform_reference(self):
         """Estimate the true signal mean and interpolate bad channels.
@@ -108,6 +109,7 @@ class Reference:
             "bad_by_ransac": noisy_detector.bad_by_ransac,
             "bad_all": noisy_detector.get_bads(),
         }
+        self._extra_info['interpolated'] = noisy_detector._extra_info
 
         bad_channels = _union(self.bad_before_interpolation, self.unusable_channels)
         self.raw.info["bads"] = bad_channels
@@ -141,6 +143,7 @@ class Reference:
             "bad_by_ransac": noisy_detector.bad_by_ransac,
             "bad_all": noisy_detector.get_bads(),
         }
+        self._extra_info['remaining_bad'] = noisy_detector._extra_info
 
         return self
 
@@ -183,6 +186,7 @@ class Reference:
             "bad_by_ransac": noisy_detector.bad_by_ransac,
             "bad_all": noisy_detector.get_bads(),
         }
+        self._extra_info['initial_bad'] = noisy_detector._extra_info
 
         self.noisy_channels = self.noisy_channels_original.copy()
         logger.info("Bad channels: {}".format(self.noisy_channels))


### PR DESCRIPTION
<!--Thanks for contributing-->
<!--If this is your first time, please make sure to read the contributing guideline-->
<!--https://github.com/sappelhoff/pyprep/blob/master/.github/CONTRIBUTING.md-->

# PR Description

In MATLAB PREP, various values and matrices calculated during findNoisyChannels are saved as part of the resulting EEG object. These include the raw correlation values for each RANSAC window and each correlation window, the calculated noisiness and deviations for each channel, the dropout windows, and more. MATLAB PREP also does some extra calculations with some of this data when generating reports that otherwise isn't used in bad channel detection (e.g. reporting the specific windows of high frequency noise across each channel). Here's what MatPREP retains for the initial, pre-interpolation, and post-interpolation findNoisyChannels runs:

![Screen Shot 2021-04-18 at 7 53 29 PM](https://user-images.githubusercontent.com/18648066/115163502-d16ffc00-a07f-11eb-99b6-d8b64aa517a1.png)

This PR makes PyPREP retain most of the same detailed info.

The immediate purpose of the PR is that this will make it a lot easier to do proper and detailed unit tests, especially for comparing values between PyPREP and MATLAB PREP. Instead of just testing channel detection output, we can now test whether specific values match up with what we expect.

The other purpose of the PR is that (at some point) we might want to make this part of the public API, so that people can access and dig into these values like they can with MATLAB PREP, and/or add functions to do the additional calculations with some of this data the way MatPREP does.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [whats_new.rst][whats-new-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[whats-new-file]: https://github.com/sappelhoff/pyprep/blob/master/docs/whats_new.rst
