### PR TITLE
Change initial re-referencing state in Reference to match Matlab PREP

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -43,6 +43,8 @@ Changelog
 - Added a ``matlab_strict`` method for high-pass trend removal, exactly matching MATLAB PREP's values if ``matlab_strict`` is enabled, by `Austin Hurst`_ (:gh:`71`)
 - Added a window-wise implementaion of RANSAC and made it the default method, reducing the typical RAM demands of robust re-referencing considerably, by `Austin Hurst`_ (:gh:`66`)
 - Added `max_chunk_size` parameter for specifying the maximum chunk size to use for channel-wise RANSAC, allowing more control over PyPREP RAM usage, by `Austin Hurst`_ (:gh:`66`)
+- Changed :class:`~pyprep.Reference` to exclude "bad-by-SNR" channels from initial average referencing, matching MATLAB PREP behaviour, by `Austin Hurst`_ (:gh:`78`)
+- Changed :class:`~pyprep.Reference` to only flag "unusable" channels (bad by flat, NaNs, or low SNR) from the first pass of noisy detection for permanent exclusion from the reference signal, matching MATLAB PREP behaviour, by `Austin Hurst`_ (:gh:`78`)
 
 Bug
 ~~~

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -230,15 +230,11 @@ class Reference:
         self.noisy_channels = self.noisy_channels_original.copy()
         logger.info("Bad channels: {}".format(self.noisy_channels))
 
+        # Determine channels to use/exclude from initial reference estimation
         self.unusable_channels = _union(
-            noisy_detector.bad_by_nan, noisy_detector.bad_by_flat
+            noisy_detector.bad_by_nan + noisy_detector.bad_by_flat,
+            noisy_detector.bad_by_SNR
         )
-
-        # According to the Matlab Implementation (see robustReference.m)
-        # self.unusable_channels = _union(self.unusable_channels,
-        # noisy_detector.bad_by_SNR)
-        # but maybe this makes no difference...
-
         self.reference_channels = _set_diff(
             self.reference_channels, self.unusable_channels
         )

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -226,9 +226,7 @@ class Reference:
             "bad_all": noisy_detector.get_bads(),
         }
         self._extra_info['initial_bad'] = noisy_detector._extra_info
-
-        self.noisy_channels = self.noisy_channels_original.copy()
-        logger.info("Bad channels: {}".format(self.noisy_channels))
+        logger.info("Bad channels: {}".format(self.noisy_channels_original))
 
         # Determine channels to use/exclude from initial reference estimation
         self.unusable_channels = _union(
@@ -238,6 +236,19 @@ class Reference:
         self.reference_channels = _set_diff(
             self.reference_channels, self.unusable_channels
         )
+
+        # Initialize channels to permanently flag as bad during referencing
+        self.noisy_channels = {
+            "bad_by_nan": noisy_detector.bad_by_nan,
+            "bad_by_flat": noisy_detector.bad_by_flat,
+            "bad_by_deviation": [],
+            "bad_by_hf_noise": [],
+            "bad_by_correlation": [],
+            "bad_by_SNR": noisy_detector.bad_by_SNR,
+            "bad_by_dropout": [],
+            "bad_by_ransac": [],
+            "bad_all": self.unusable_channels,
+        }
 
         # Get initial estimate of the reference by the specified method
         signal = raw.get_data() * 1e6


### PR DESCRIPTION
<!--Thanks for contributing-->
<!--If this is your first time, please make sure to read the contributing guideline-->
<!--https://github.com/sappelhoff/pyprep/blob/master/.github/CONTRIBUTING.md-->

# PR Description

Closes #75 and closes #76. This PR fixes two separate (but related) issues:

- Unlike PyPREP, MatPREP considers bad-by-SNR channels to be 'unuseable' for its initial average reference (in addition to bad-by-NaN and bad-by-flat channels)
- Unlike PyPREP, MatPREP only flags the above "unusable" channels for permanent exclusion from being reference channels after the first noisy channels pass. PyPREP includes bad channels detected by all methods from this pass as permanently unusable, which doesn't necessarily make sense if the data isn't already average referenced (e.g. single-channel referenced or CMS/DRL).

With these fixes, PyPREP and Matlab PREP have identical values during re-referencing up until the second pass of NoisyChannels (see #74).

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [x] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [whats_new.rst][whats-new-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[whats-new-file]: https://github.com/sappelhoff/pyprep/blob/master/docs/whats_new.rst
