### PR TITLE
Add initial tests for removeTrend & NoisyChannels

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -45,6 +45,9 @@ Changelog
 - Added `max_chunk_size` parameter for specifying the maximum chunk size to use for channel-wise RANSAC, allowing more control over PyPREP RAM usage, by `Austin Hurst`_ (:gh:`66`)
 - Changed :class:`~pyprep.Reference` to exclude "bad-by-SNR" channels from initial average referencing, matching MATLAB PREP behaviour, by `Austin Hurst`_ (:gh:`78`)
 - Changed :class:`~pyprep.Reference` to only flag "unusable" channels (bad by flat, NaNs, or low SNR) from the first pass of noisy detection for permanent exclusion from the reference signal, matching MATLAB PREP behaviour, by `Austin Hurst`_ (:gh:`78`)
+- Added a framework for automated testing of PyPREP's components against their MATLAB PREP counterparts (using ``.mat`` and ``.set`` files generated with the `matprep_artifacts`_ script), helping verify that the two PREP implementations are numerically equivalent when `matlab_strict` is ``True``, by `Austin Hurst`_ (:gh:`79`)
+
+.. matprep_artifacts: https://github.com/a-hurst/matprep_artifacts
 
 Bug
 ~~~
@@ -54,6 +57,7 @@ Bug
 - Fixed a bug where EEG data was getting reshaped into RANSAC windows incorrectly (channel samples were not sequential), which was causing considerable variability and noise in RANSAC results, by `Austin Hurst`_ (:gh:`67`)
 - Fixed RANSAC to avoid making unnecessary signal predictions for known-bad channels, matching MATLAB behaviour and reducing RAM requirements, by `Austin Hurst`_ (:gh:`72`)
 - Fixed a bug in :meth:`NoisyChannels.find_bad_by_correlation` that prevented it from being able to handle channels with dropouts (intermittent flat regions), by `Austin Hurst`_ (:gh:`81`).
+- Fixed :class:`~pyprep.NoisyChannels` so that it always runs "bad channel by NaN" and "bad channel by flat" detection, preventing these channels from causing problems with other :class:`~pyprep.NoisyChannels` methods, by `Austin Hurst`_ (:gh:`79`)
 
 API
 ~~~

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -90,7 +90,7 @@ class NoisyChannels:
         bads_by_nan_flat = self.bad_by_nan + self.bad_by_flat
 
         # Make a subset of the data containing only usable EEG channels
-        self.usable_idx = np.isin(ch_names, bads_by_nan_flat) == False
+        self.usable_idx = np.isin(ch_names, bads_by_nan_flat, invert=True)
         self.EEGData = self.raw_mne.get_data(picks=ch_names[self.usable_idx])
         self.EEGData_beforeFilt = self.EEGData
 

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -49,24 +49,13 @@ class NoisyChannels:
         assert isinstance(raw, mne.io.BaseRaw)
 
         self.raw_mne = raw.copy()
+        self.raw_mne.pick_types(eeg=True)
         self.sample_rate = raw.info["sfreq"]
         if do_detrend:
             self.raw_mne._data = removeTrend(
                 self.raw_mne.get_data(), self.sample_rate, matlab_strict=matlab_strict
             )
         self.matlab_strict = matlab_strict
-
-        self.EEGData = self.raw_mne.get_data(picks="eeg")
-        self.EEGData_beforeFilt = self.EEGData
-        self.ch_names_original = np.asarray(raw.info["ch_names"])
-        self.n_chans_original = len(self.ch_names_original)
-        self.n_chans_new = self.n_chans_original
-        self.original_dimensions = np.shape(self.EEGData)
-        self.new_dimensions = self.original_dimensions
-        self.original_channels = np.arange(self.original_dimensions[0])
-        self.new_channels = self.original_channels
-        self.ch_names_new = self.ch_names_original
-        self.channels_interpolate = self.original_channels
 
         # Extra data for debugging
         self._extra_info = {
@@ -89,6 +78,25 @@ class NoisyChannels:
         self.bad_by_SNR = []
         self.bad_by_dropout = []
         self.bad_by_ransac = []
+
+        # Get original EEG channel names, channel count & samples
+        ch_names = np.asarray(self.raw_mne.info["ch_names"])
+        self.ch_names_original = ch_names
+        self.n_chans_original = len(ch_names)
+        self.n_samples = raw._data.shape[1]
+
+        # Before anything else, flag bad-by-NaNs and bad-by-flats
+        self.find_bad_by_nan_flat()
+        bads_by_nan_flat = self.bad_by_nan + self.bad_by_flat
+
+        # Make a subset of the data containing only usable EEG channels
+        self.usable_idx = np.isin(ch_names, bads_by_nan_flat) == False
+        self.EEGData = self.raw_mne.get_data(picks=ch_names[self.usable_idx])
+        self.EEGData_beforeFilt = self.EEGData
+
+        # Get usable EEG channel names & channel counts
+        self.ch_names_new = np.asarray(ch_names[self.usable_idx])
+        self.n_chans_new = len(self.ch_names_new)
 
     def get_bads(self, verbose=False):
         """Get a list of all bad channels.
@@ -186,35 +194,23 @@ class NoisyChannels:
 
     def find_bad_by_nan_flat(self):
         """Detect channels that appear flat or have NaN values."""
-        nan_channel_mask = [False] * self.original_dimensions[0]
-        no_signal_channel_mask = [False] * self.original_dimensions[0]
+        # Get all EEG channels from original copy of data
+        EEGData = self.raw_mne.get_data()
 
+        # Detect channels containing any NaN values
+        nan_channel_mask = np.isnan(np.sum(EEGData, axis=1))
+        nan_channels = self.ch_names_original[nan_channel_mask]
+
+        # Detect channels with flat or extremely weak signals
         FLAT_THRESHOLD = 1e-15  # corresponds to 10e-10 µV in MATLAB PREP
-        for i in range(0, self.original_dimensions[0]):
-            nan_channel_mask[i] = np.sum(np.isnan(self.EEGData[i, :])) > 0
-        for i in range(0, self.original_dimensions[0]):
-            no_signal_channel_mask[i] = (
-                robust.mad(self.EEGData[i, :], c=1) < FLAT_THRESHOLD
-                or np.std(self.EEGData[i, :]) < FLAT_THRESHOLD
-            )
-        nan_channels = self.channels_interpolate[nan_channel_mask]
-        flat_channels = self.channels_interpolate[no_signal_channel_mask]
+        flat_by_mad = robust.mad(EEGData, axis=1, c=1) < FLAT_THRESHOLD
+        flat_by_stdev = np.std(EEGData, axis=1) < FLAT_THRESHOLD
+        flat_channel_mask = flat_by_mad | flat_by_stdev
+        flat_channels = self.ch_names_original[flat_channel_mask]
 
-        nans_no_data_channels = np.union1d(nan_channels, flat_channels)
-        self.channels_interpolate = np.setdiff1d(
-            self.channels_interpolate, nans_no_data_channels
-        )
-
-        for i in range(0, len(nan_channels)):
-            self.bad_by_nan.append(self.ch_names_original[nan_channels[i]])
-        for i in range(0, len(flat_channels)):
-            self.bad_by_flat.append(self.ch_names_original[flat_channels[i]])
-
-        self.raw_mne.drop_channels(list(set(self.bad_by_nan + self.bad_by_flat)))
-        self.EEGData = self.raw_mne.get_data(picks="eeg")
-        self.ch_names_new = np.asarray(self.raw_mne.info["ch_names"])
-        self.n_chans_new = len(self.ch_names_new)
-        self.new_dimensions = np.shape(self.EEGData)
+        # Update names of bad channels by NaN or flat signal
+        self.bad_by_nan = nan_channels.tolist()
+        self.bad_by_flat = flat_channels.tolist()
 
     def find_bad_by_deviation(self, deviation_threshold=5.0):
         """Robust z-score of the robust standard deviation for each channel is calculated.
@@ -227,22 +223,22 @@ class NoisyChannels:
             z-score threshold above which channels will be labelled bad.
 
         """
-        deviation_channel_mask = [False] * (self.new_dimensions[0])
-        channel_deviation = np.zeros(self.new_dimensions[0])
-        for i in range(0, self.new_dimensions[0]):
+        deviation_channel_mask = [False] * (self.n_chans_original)
+        robust_channel_deviation = np.zeros(self.n_chans_original, dtype=np.float64)
+        channel_deviation = np.zeros(self.n_chans_new)
+        for i in range(0, self.n_chans_new):
             channel_deviation[i] = 0.7413 * _mat_iqr(self.EEGData[i, :])
         channel_deviationSD = 0.7413 * _mat_iqr(channel_deviation)
         channel_deviationMedian = np.nanmedian(channel_deviation)
-        robust_channel_deviation = np.divide(
+        robust_channel_deviation[self.usable_idx] = np.divide(
             np.subtract(channel_deviation, channel_deviationMedian), channel_deviationSD
         )
-        for i in range(0, self.new_dimensions[0]):
+        for i in range(0, self.n_chans_original):
             deviation_channel_mask[i] = abs(
                 robust_channel_deviation[i]
             ) > deviation_threshold or np.isnan(robust_channel_deviation[i])
-        deviation_channels = self.channels_interpolate[deviation_channel_mask]
-        for i in range(0, len(deviation_channels)):
-            self.bad_by_deviation.append(self.ch_names_original[deviation_channels[i]])
+        deviation_channels = self.ch_names_original[deviation_channel_mask]
+        self.bad_by_deviation = deviation_channels.tolist()
         self._extra_info['bad_by_deviation'].update({
             'median_channel_deviation': channel_deviationMedian,
             'channel_deviation_sd': channel_deviationSD,
@@ -266,6 +262,7 @@ class NoisyChannels:
         """
         data_tmp = np.transpose(self.EEGData)
         dimension = np.shape(data_tmp)
+        zscore_HFNoise = np.zeros(self.n_chans_original, dtype=np.float64)
         if self.sample_rate > 100:
             EEG_filt = np.zeros((dimension[0], dimension[1]))
             bandpass_filter = filter_design(
@@ -284,25 +281,19 @@ class NoisyChannels:
                 np.median(np.absolute(np.subtract(noisiness, np.median(noisiness))))
                 * 1.4826
             )
-            zscore_HFNoise = np.divide(
+            zscore_HFNoise[self.usable_idx] = np.divide(
                 np.subtract(noisiness, noisiness_median), noiseSD
             )
-            HFnoise_channel_mask = [False] * self.new_dimensions[0]
-            for i in range(0, self.new_dimensions[0]):
-                HFnoise_channel_mask[i] = zscore_HFNoise[
-                    i
-                ] > HF_zscore_threshold or np.isnan(zscore_HFNoise[i])
-            HFNoise_channels = self.channels_interpolate[HFnoise_channel_mask]
+            hf_mask = np.isnan(zscore_HFNoise) | (zscore_HFNoise > HF_zscore_threshold)
+            HFNoise_channels = self.ch_names_original[hf_mask]
         else:
             EEG_filt = data_tmp
             noisiness_median = 0
-            # noisinessSD = 1
-            zscore_HFNoise = np.zeros((self.new_dimensions[0], 1))
-            HFNoise_channels = []
+            noiseSD = 1
+            HFNoise_channels = np.asarray([])
         self.EEGData_beforeFilt = data_tmp
         self.EEGData = np.transpose(EEG_filt)
-        for i in range(0, len(HFNoise_channels)):
-            self.bad_by_hf_noise.append(self.ch_names_original[HFNoise_channels[i]])
+        self.bad_by_hf_noise = HFNoise_channels.tolist()
         self._extra_info['bad_by_hf_noise'].update({
             'median_channel_noisiness': noisiness_median,
             'channel_noisiness_sd': noiseSD,
@@ -337,30 +328,29 @@ class NoisyChannels:
 
         """
         self.find_bad_by_hfnoise()  # since filtering is performed there
+        usable_idx = self.usable_idx
         correlation_frames = correlation_secs * self.sample_rate
         correlation_window = np.arange(correlation_frames)
         correlation_offsets = np.arange(
-            1, (self.new_dimensions[1] - correlation_frames), correlation_frames
+            1, (self.n_samples - correlation_frames), correlation_frames
         )
         w_correlation = len(correlation_offsets)
-        maximum_correlations = np.ones((self.original_dimensions[0], w_correlation))
-        drop_out = np.zeros((self.new_dimensions[0], w_correlation))
-        channel_correlation = np.ones((w_correlation, self.new_dimensions[0]))
-        noiselevels = np.zeros((w_correlation, self.new_dimensions[0]))
-        channel_deviations = np.zeros((w_correlation, self.new_dimensions[0]))
-        drop = np.zeros((w_correlation, self.new_dimensions[0]))
+        channel_correlation = np.ones((w_correlation, self.n_chans_original))
+        noiselevels = np.zeros((w_correlation, self.n_chans_original))
+        channel_deviations = np.zeros((w_correlation, self.n_chans_original))
+        drop = np.zeros((w_correlation, self.n_chans_original))
         len_correlation_window = len(correlation_window)
         EEGData = np.transpose(self.EEGData)
         EEG_new_win = np.reshape(
             np.transpose(EEGData[0 : len_correlation_window * w_correlation, :]),
-            (self.new_dimensions[0], len_correlation_window, w_correlation),
+            (self.n_chans_new, len_correlation_window, w_correlation),
             order="F",
         )
         data_win = np.reshape(
             np.transpose(
                 self.EEGData_beforeFilt[0 : len_correlation_window * w_correlation, :]
             ),
-            (self.new_dimensions[0], len_correlation_window, w_correlation),
+            (self.n_chans_new, len_correlation_window, w_correlation),
             order="F",
         )
         for k in range(0, w_correlation):
@@ -371,41 +361,38 @@ class NoisyChannels:
             abs_corr = np.abs(
                 np.subtract(window_correlation, np.diag(np.diag(window_correlation)))
             )
-            channel_correlation[k, :] = _mat_quantile(abs_corr, 0.98, axis=0)
+            channel_correlation[k, usable_idx] = _mat_quantile(abs_corr, 0.98, axis=0)
             with np.errstate(invalid='ignore'):  # suppress divide-by-zero warnings
-                noiselevels[k, :] = np.divide(
+                noiselevels[k, usable_idx] = np.divide(
                     robust.mad(np.subtract(data_portion, eeg_portion), c=1),
                     robust.mad(eeg_portion, c=1),
                 )
-            channel_deviations[k, :] = 0.7413 * _mat_iqr(data_portion, axis=0)
+            channel_deviations[k, usable_idx] = 0.7413 * _mat_iqr(data_portion, axis=0)
         for i in range(0, w_correlation):
-            for j in range(0, self.new_dimensions[0]):
+            for j in range(0, self.n_chans_original):
                 drop[i, j] = np.int(
                     np.isnan(channel_correlation[i, j]) or np.isnan(noiselevels[i, j])
                 )
                 if drop[i, j] == 1:
                     channel_correlation[i, j] = 0
                     noiselevels[i, j] = 0
-        maximum_correlations[self.channels_interpolate, :] = np.transpose(
-            channel_correlation
-        )
-        drop_out[:] = np.transpose(drop)
+
+        # Flag channels with above-threshold fractions of bad correlation windows
+        maximum_correlations = np.transpose(channel_correlation)
         thresholded_correlations = maximum_correlations < correlation_threshold
         thresholded_correlations = thresholded_correlations.astype(int)
         fraction_BadCorrelationWindows = np.mean(thresholded_correlations, axis=1)
+        bad_correlation_mask = fraction_BadCorrelationWindows > frac_bad
+        bad_correlation_channels = self.ch_names_original[bad_correlation_mask]
+        self.bad_by_correlation = bad_correlation_channels.tolist()
+
+        # Flag channels with above-threshold fractions of drop-out windows
+        drop_out = np.transpose(drop)
         fraction_BadDropOutWindows = np.mean(drop_out, axis=1)
+        dropout_mask = fraction_BadDropOutWindows > frac_bad
+        dropout_channels = self.ch_names_original[dropout_mask]
+        self.bad_by_dropout = dropout_channels.tolist()
 
-        bad_correlation_channels_idx = np.argwhere(
-            fraction_BadCorrelationWindows > frac_bad
-        )
-        bad_correlation_channels_name = self.ch_names_original[
-            bad_correlation_channels_idx.astype(int)
-        ]
-        self.bad_by_correlation = [i[0] for i in bad_correlation_channels_name]
-
-        dropout_channels_idx = np.argwhere(fraction_BadDropOutWindows > frac_bad)
-        dropout_channels_name = self.ch_names_original[dropout_channels_idx.astype(int)]
-        self.bad_by_dropout = [i[0] for i in dropout_channels_name]
         self._extra_info['bad_by_correlation'] = {
             'max_correlations': maximum_correlations,
             'median_max_correlations': np.median(maximum_correlations, axis=1),
@@ -503,11 +490,11 @@ class NoisyChannels:
             self.bad_by_deviation +
             self.bad_by_dropout
         )
-        self.bad_by_ransac, ch_correlations = find_bad_by_ransac(
+        self.bad_by_ransac, ch_correlations_usable = find_bad_by_ransac(
             self.EEGData,
             self.sample_rate,
             self.ch_names_new,
-            self.raw_mne._get_channel_positions(),
+            self.raw_mne._get_channel_positions()[self.usable_idx, :],
             exclude_from_ransac,
             n_samples,
             fraction_good,
@@ -519,6 +506,12 @@ class NoisyChannels:
             self.random_state,
             self.matlab_strict,
         )
+
+        # Reshape correlation matrix to match original channel count
+        n_ransac_windows = ch_correlations_usable.shape[0]
+        ch_correlations = np.ones((n_ransac_windows, self.n_chans_original))
+        ch_correlations[:, self.usable_idx] = ch_correlations_usable
+
         self._extra_info['bad_by_ransac'] = {
             'ransac_correlations': ch_correlations,
             'bad_window_fractions': np.mean(ch_correlations < corr_thresh, axis=0)

--- a/tests/test_find_noisy_channels.py
+++ b/tests/test_find_noisy_channels.py
@@ -118,6 +118,12 @@ def test_findnoisychannels(raw, montage):
     nd.find_bad_by_hfnoise()
     assert rand_chn_lab in nd.bad_by_hf_noise
 
+    # Test for high freq noise detection when sample rate < 100 Hz
+    raw_tmp.resample(80)  # downsample to 80 Hz
+    nd = NoisyChannels(raw_tmp, random_state=rng)
+    nd.find_bad_by_hfnoise()
+    assert len(nd.bad_by_hf_noise) == 0
+
     # Test for signal to noise ratio in EEG data
     raw_tmp = raw.copy()
     m, n = raw_tmp._data.shape

--- a/tests/test_matprep_compare.py
+++ b/tests/test_matprep_compare.py
@@ -59,11 +59,11 @@ def matprep_noisy(matprep_artifacts):
     # Read in and parse noisy channel info artifact from MATLAB PREP
     info_path = matprep_artifacts['matprep_info']
     matprep_info = scipy.io.loadmat(info_path, simplify_cells=True)['prep_info']
-    matprep_noisy_all = matprep_info['noiseDetection']['reference']
+    matprep_noisy_all = matprep_info['reference']
     matprep_noisy = matprep_noisy_all['noisyStatisticsOriginal']
 
     # Gather bad channel names from MatPREP, converting numbers to labels
-    ch_names = matprep_info['noiseDetection']['originalChannelLabels']
+    ch_names = matprep_info['originalChannelLabels']
     bad_types = {
         'badChannelsFromNaNs': 'by_nan',
         'badChannelsFromNoData': 'by_flat',
@@ -135,15 +135,21 @@ def test_compare_removeTrend(matprep_artifacts):
 
     # Check MATLAB equivalence at start of recording
     win_size = 500  # window of samples to check
-    assert np.allclose(expected[:, :win_size], actual[:, :win_size])
+    assert np.allclose(
+        actual[:, :win_size], expected[:, :win_size], equal_nan=True
+    )
 
     # Check MATLAB equivalence in middle of recording
     win_start = int(actual.shape[1] / 2)
     win_end = win_start + win_size
-    assert np.allclose(expected[:, win_start:win_end], actual[:, win_start:win_end])
+    assert np.allclose(
+        actual[:, win_start:win_end], expected[:, win_start:win_end], equal_nan=True
+    )
 
     # Check MATLAB equivalence at end of recording
-    assert np.allclose(expected[:, -win_size:], actual[:, -win_size:])
+    assert np.allclose(
+        actual[:, -win_size:], expected[:, -win_size:], equal_nan=True
+    )
 
 
 class TestCompareNoisyChannels(object):
@@ -252,7 +258,9 @@ class TestCompareNoisyChannels(object):
 
     def test_bad_by_SNR(self, pyprep_noisy, matprep_noisy):
         """Compare bad-by-SNR results between PyPREP and MatPREP."""
-        assert pyprep_noisy.bad_by_SNR == matprep_noisy['bads']['by_SNR']
+        pyprep_bads_snr = sorted(pyprep_noisy.bad_by_SNR)
+        matprep_bads_snr = sorted(matprep_noisy['bads']['by_SNR'])
+        assert pyprep_bads_snr == matprep_bads_snr
 
     def test_bad_by_dropout(self, pyprep_noisy, matprep_noisy):
         """Compare bad-by-dropout results between PyPREP and MatPREP."""

--- a/tests/test_matprep_compare.py
+++ b/tests/test_matprep_compare.py
@@ -1,0 +1,297 @@
+"""Compare PyPREP results to MATLAB PREP."""
+from urllib.request import urlopen
+import numpy as np
+import scipy
+import mne
+
+import pytest
+
+from pyprep.find_noisy_channels import NoisyChannels
+from pyprep.removeTrend import removeTrend
+
+
+# Define some fixtures for things that will be used across multiple tests
+
+@pytest.fixture(scope='session')
+def matprep_artifacts(tmpdir_factory):
+    """Fixture for downloading & using MATLAB PREP artifacts from CI.
+
+    Downloads the latest set of CI-generated MATLAB PREP artifacts and saves
+    them to a temporary folder for use with various tests, returning the paths
+    to each artifact in a {name: path} dict. The temporary folder will be
+    automatically cleaned up by pytest once all tests have completed.
+
+    """
+    base_url = "https://github.com/a-hurst/matprep_artifacts/releases/latest/download/"
+    artifacts = [
+        "1_matprep_raw.set",
+        "2_matprep_removetrend.set",
+        "3_matprep_cleanline.set",
+        "4_matprep_pre_reference.set",
+        "5_matprep_post_reference.set",
+        "matprep_info.mat"
+    ]
+    dirpath = tmpdir_factory.mktemp("artifacts")
+
+    artifact_paths = {}
+    for f in artifacts:
+        artifact_name = f.split(".")[0]
+        outfile = str(dirpath.join(f))
+        dl = urlopen(base_url + f)
+        with open(outfile, 'wb') as out:
+            out.write(dl.read())
+        artifact_paths[artifact_name] = outfile
+
+    return artifact_paths
+
+
+@pytest.fixture(scope='session')
+def matprep_noisy(matprep_artifacts):
+    """Import and preprocess artifact containing MATLAB PREP runtime info.
+
+    This fixture only parses and retains data from the first pass of noisy
+    channel detection during re-referencing, since it's easiest to compare with
+    PyPREP. It also adds a new key to the imported struct, 'bads', which
+    contains the names of the channels flagged as bad by each detection
+    method (as opposed to just channel indices).
+
+    """
+    # Read in and parse noisy channel info artifact from MATLAB PREP
+    info_path = matprep_artifacts['matprep_info']
+    matprep_info = scipy.io.loadmat(info_path, simplify_cells=True)['prep_info']
+    matprep_noisy_all = matprep_info['noiseDetection']['reference']
+    matprep_noisy = matprep_noisy_all['noisyStatisticsOriginal']
+
+    # Gather bad channel names from MatPREP, converting numbers to labels
+    ch_names = matprep_info['noiseDetection']['originalChannelLabels']
+    bad_types = {
+        'badChannelsFromNaNs': 'by_nan',
+        'badChannelsFromNoData': 'by_flat',
+        'badChannelsFromDeviation': 'by_deviation',
+        'badChannelsFromHFNoise': 'by_hf_noise',
+        'badChannelsFromCorrelation': 'by_correlation',
+        'badChannelsFromLowSNR': 'by_SNR',
+        'badChannelsFromDropOuts': 'by_dropout',
+        'badChannelsFromRansac': 'by_ransac',
+        'all': 'all',
+    }
+    matprep_bads = {}
+    for bad_type, name in bad_types.items():
+        bads_idx = matprep_noisy['noisyChannels'][bad_type]
+        bads_idx = [bads_idx] if isinstance(bads_idx, int) else bads_idx
+        matprep_bads[name] = [ch_names[i-1] for i in bads_idx]
+    matprep_noisy['bads'] = matprep_bads
+
+    return matprep_noisy
+
+
+@pytest.fixture(scope='session')
+def pyprep_noisy(matprep_artifacts):
+    """Get original NoisyChannels results for comparison with MATLAB PREP.
+
+    This fixture uses an artifact from MATLAB PREP of the CleanLined and
+    detrended EEG signal right before MATLAB PREP runs its first iteration of
+    NoisyChannels during re-referncing. As such, any differences in test results
+    will be due to actual differences in the noisy channel detection code rather
+    than differences at an earlier stage of the pipeline.
+
+    """
+    # Import pre-reference MATLAB PREP data
+    preref_path = matprep_artifacts['4_matprep_pre_reference']
+    matprep_preref = mne.io.read_raw_eeglab(preref_path, preload=True)
+
+    # Run NoisyChannels on MATLAB data and extract internal noisy info
+    matprep_seed = 435656
+    pyprep_noisy = NoisyChannels(
+        matprep_preref,
+        do_detrend=False,
+        random_state=matprep_seed,
+        matlab_strict=True
+    )
+    pyprep_noisy.find_all_bads()
+
+    return pyprep_noisy
+
+
+# Define MATLAB comparison tests for each main component of PyPREP
+
+@pytest.mark.usefixtures('matprep_artifacts')
+def test_compare_removeTrend(matprep_artifacts):
+    """Test the numeric equivalence of removeTrend to MATLAB PREP."""
+    # Get paths of MATLAB .set files
+    raw_path = matprep_artifacts['1_matprep_raw']
+    detrend_path = matprep_artifacts['2_matprep_removetrend']
+
+    # Load relevant MATLAB data
+    matprep_raw = mne.io.read_raw_eeglab(raw_path, preload=True)
+    matprep_detrended = mne.io.read_raw_eeglab(detrend_path, preload=True)
+    sample_rate = matprep_raw.info["sfreq"]
+
+    # Apply removeTrend to raw artifact to get expected and actual signals
+    expected = matprep_detrended._data
+    actual = removeTrend(
+        matprep_raw._data, sample_rate, detrendType="high pass", matlab_strict=True
+    )
+
+    # Check MATLAB equivalence at start of recording
+    win_size = 500  # window of samples to check
+    assert np.allclose(expected[:, :win_size], actual[:, :win_size])
+
+    # Check MATLAB equivalence in middle of recording
+    win_start = int(actual.shape[1] / 2)
+    win_end = win_start + win_size
+    assert np.allclose(expected[:, win_start:win_end], actual[:, win_start:win_end])
+
+    # Check MATLAB equivalence at end of recording
+    assert np.allclose(expected[:, -win_size:], actual[:, -win_size:])
+
+
+class TestCompareNoisyChannels(object):
+    """Compare the results of NoisyChannels to the equivalent MatPREP code.
+
+    These comparisons use input data that's already had adaptive line noise
+    removal and high-pass trend removal done to the signal, so any differences
+    found will be due to differences in the noisy channel detection code rather
+    than any differences at an earlier stage of the pipeline.
+
+    """
+
+    def test_bad_by_nan(self, pyprep_noisy, matprep_noisy):
+        """Compare bad-by-NaN results between PyPREP and MatPREP."""
+        # NOTE: The current test artifacts contain no channels with NaN values
+        # (when does that ever happen?), meaning that this may not be testing
+        # anything useful
+        assert pyprep_noisy.bad_by_nan == matprep_noisy['bads']['by_nan']
+
+    def test_bad_by_flat(self, pyprep_noisy, matprep_noisy):
+        """Compare bad-by-flat results between PyPREP and MatPREP."""
+        # NOTE: The current test artifacts contain no flat channels, meaning
+        # that this may not be testing anything useful
+        assert pyprep_noisy.bad_by_flat == matprep_noisy['bads']['by_flat']
+
+    def test_bad_by_deviation(self, pyprep_noisy, matprep_noisy):
+        """Compare bad-by-deviation results between PyPREP and MatPREP."""
+        # Gather PyPREP deviation info and MATLAB equivalents
+        mat = matprep_noisy
+        matprep_info = {
+            'median_channel_deviation': mat['channelDeviationMedian'],
+            'channel_deviation_sd': mat['channelDeviationSD'],
+            'robust_channel_deviations': mat['robustChannelDeviation'],
+            'channel_deviations': mat['channelDeviations']
+        }
+        pyprep_info = pyprep_noisy._extra_info['bad_by_deviation']
+
+        # Compare overall medians and SDs for channel deviations
+        median_dev = 'median_channel_deviation'
+        dev_sd = 'channel_deviation_sd'
+        assert np.isclose(pyprep_info[median_dev] * 1e6, matprep_info[median_dev])
+        assert np.isclose(pyprep_info[dev_sd] * 1e6, matprep_info[dev_sd])
+
+        # Compare robust deviations across channels
+        dev_by_chan = 'robust_channel_deviations'
+        assert np.allclose(pyprep_info[dev_by_chan], matprep_info[dev_by_chan])
+
+        # Compare windows of channel deviations across recording
+        chan_devs = 'channel_deviations'
+        assert np.allclose(pyprep_info[chan_devs] * 1e6, matprep_info[chan_devs].T)
+
+        # Compare names of bad-by-deviation channels
+        assert pyprep_noisy.bad_by_deviation == matprep_noisy['bads']['by_deviation']
+
+    def test_bad_by_hf_noise(self, pyprep_noisy, matprep_noisy):
+        """Compare bad-by-HF-noise results between PyPREP and MatPREP."""
+        # Gather PyPREP high-frequency noise info and MATLAB equivalents
+        mat = matprep_noisy
+        matprep_info = {
+            'median_channel_noisiness': mat['noisinessMedian'],
+            'channel_noisiness_sd': mat['noisinessSD'],
+            'hf_noise_zscores': mat['zscoreHFNoise'],
+            'noise_levels': mat['noiseLevels']
+        }
+        pyprep_info = pyprep_noisy._extra_info['bad_by_hf_noise']
+
+        # Compare overall medians and SDs for channel noisiness
+        median_noise = 'median_channel_noisiness'
+        noise_sd = 'channel_noisiness_sd'
+        assert np.isclose(pyprep_info[median_noise], matprep_info[median_noise])
+        assert np.isclose(pyprep_info[noise_sd], matprep_info[noise_sd])
+
+        # Compare noisiness z-scores across channels
+        TOL = 1e-5  # NOTE: Some diffs > 1e-6 (default), maybe slight diff in math?
+        noise_z = 'hf_noise_zscores'
+        assert np.allclose(pyprep_info[noise_z], matprep_info[noise_z], atol=TOL)
+
+        # Compare windows of noisiness per channel across recording
+        noise_win = 'noise_levels'
+        assert np.allclose(pyprep_info[noise_win], matprep_info[noise_win].T)
+
+        # Compare names of bad-by-HF-noise channels
+        assert pyprep_noisy.bad_by_hf_noise == matprep_noisy['bads']['by_hf_noise']
+
+    def test_bad_by_correlation(self, pyprep_noisy, matprep_noisy):
+        """Compare bad-by-correlation results between PyPREP and MatPREP."""
+        # Gather PyPREP correlation info and MATLAB equivalents
+        mat = matprep_noisy
+        matprep_info = {
+            'max_correlations': mat['maximumCorrelations'],
+            'median_max_correlations': mat['medianMaxCorrelation']
+        }
+        pyprep_info = pyprep_noisy._extra_info['bad_by_correlation']
+
+        # Compare median maximum correlations across channels
+        med_max_corr = 'median_max_correlations'
+        assert np.allclose(pyprep_info[med_max_corr], matprep_info[med_max_corr])
+
+        # Compare max correlations per channel across recording
+        max_corr = 'max_correlations'
+        assert np.allclose(pyprep_info[max_corr], matprep_info[max_corr])
+
+        # Compare names of bad-by-correlation channels
+        matprep_bad_by_corr = matprep_noisy['bads']['by_correlation']
+        assert pyprep_noisy.bad_by_correlation == matprep_bad_by_corr
+
+    def test_bad_by_SNR(self, pyprep_noisy, matprep_noisy):
+        """Compare bad-by-SNR results between PyPREP and MatPREP."""
+        assert pyprep_noisy.bad_by_SNR == matprep_noisy['bads']['by_SNR']
+
+    def test_bad_by_dropout(self, pyprep_noisy, matprep_noisy):
+        """Compare bad-by-dropout results between PyPREP and MatPREP."""
+        # NOTE: The current test artifacts contain no channels with dropouts,
+        # meaning that this may not be testing anything useful
+
+        # Gather PyPREP and MATLAB PREP dropout info
+        matprep_dropouts = matprep_noisy['dropOuts']
+        pyprep_dropouts = pyprep_noisy._extra_info['bad_by_dropout']['dropouts']
+
+        # Compare dropout windows per channel across recording
+        assert np.allclose(pyprep_dropouts, matprep_dropouts)
+
+        # Compare names of bad-by-dropout channels
+        assert pyprep_noisy.bad_by_dropout == matprep_noisy['bads']['by_dropout']
+
+    def test_bad_by_ransac(self, pyprep_noisy, matprep_noisy):
+        """Compare bad-by-RANSAC results between PyPREP and MatPREP."""
+        # Gather PyPREP RANSAC correlation info and MATLAB equivalents
+        mat = matprep_noisy
+        matprep_info = {
+            'ransac_correlations': mat['ransacCorrelations'],
+            'bad_window_fractions': mat['ransacBadWindowFraction']
+        }
+        pyprep_info = pyprep_noisy._extra_info['bad_by_ransac']
+
+        # Compare fractions of bad RANSAC windows across channels
+        bad_fracs = 'bad_window_fractions'
+        assert np.allclose(pyprep_info[bad_fracs], matprep_info[bad_fracs])
+
+        # Compare RANSAC window correlations per channel across recording
+        ransac_corr = 'ransac_correlations'
+        assert np.allclose(pyprep_info[ransac_corr], matprep_info[ransac_corr].T)
+
+        # Compare names of bad-by-RANSAC channels
+        assert pyprep_noisy.bad_by_ransac == matprep_noisy['bads']['by_ransac']
+
+    def test_all_bads(self, pyprep_noisy, matprep_noisy):
+        """Compare names of all bad channels between PyPREP and MatPREP."""
+        pyprep_bads_all = sorted(pyprep_noisy.get_bads())
+        matprep_bads_all = sorted(matprep_noisy['bads']['all'])
+        assert pyprep_bads_all == matprep_bads_all


### PR DESCRIPTION
<!--Thanks for contributing-->
<!--If this is your first time, please make sure to read the contributing guideline-->
<!--https://github.com/sappelhoff/pyprep/blob/master/.github/CONTRIBUTING.md-->

# PR Description

Closes #49. This PR aims to add direct CI comparison of PyPREP's `matlab_strict`results to Matlab PREP's across every stage of the pipeline, verifying that we're not deviating from MatPREP in any ways we're not actively aware of.

This is currently in a draft state, with only removeTrend and NoisyChannels being tested for equivalence, but I figure this would be a useful stage at which to get some feedback.

### Components currently tested

- [x] removeTrend
- [ ] CleanLine (`mne.filter.notch_filter`)
- [x] NoisyChannels
   - [x] Bad by NaN
   - [x] Bad by flat
   - [x] Bad by deviation
   - [x] Bad by HF noise
   - [x] Bad by correlation
   - [x] Bad by low SNR
   - [x] Bad by dropout
   - [x] Bad by RANSAC
- [ ] Robust re-referencing
- [ ] Final bad channel interpolation
- [ ] Full pipeline, start-to-finish

### Current thoughts

- The current test file I chose apparently only has two bad channels (T10 and FT8), none of which are bad by NaN, flat, SNR, or deviation. One possibility would be to try and find another test file that's noisier, another would be to try and simulate these types of noise as part of our `matlab_artifacts` script. Simulating bad-by-SNR is likely more trouble than just finding a noisier file, but I haven't found any data with bad-by-NaN or bad-by-dropout channels yet so I think simulation is the way to go for those.
- What do we want to do about the `examples/run_full_prep.py` script? Once #58 is finally finished it'll need to be rewritten a bit, but should we switch to using `matprep_artifacts` as the test data for that as well?
- How do we want to approach merging this? Should I write tests for the whole thing and mark the ones that aren't numerically-equivalent yet as expected failures, or should we merge once NoisyChannels tests are complete and add to this with future PRs when adding `matlab_strict` modes for things like re-referencing and final interpolation?

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [x] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [whats_new.rst][whats-new-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[whats-new-file]: https://github.com/sappelhoff/pyprep/blob/master/docs/whats_new.rst
