### PR TITLE
Fix handling of channels with dropouts (intermittent flat regions) within NoisyChannels

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -53,6 +53,7 @@ Bug
 - Changed "bad channel by deviation" and "bad channel by correlation" detection code in :class:`NoisyChannels` to compute IQR and quantiles in the same manner as MATLAB, thus producing identical results to MATLAB PREP, by `Austin Hurst`_ (:gh:`57`)
 - Fixed a bug where EEG data was getting reshaped into RANSAC windows incorrectly (channel samples were not sequential), which was causing considerable variability and noise in RANSAC results, by `Austin Hurst`_ (:gh:`67`)
 - Fixed RANSAC to avoid making unnecessary signal predictions for known-bad channels, matching MATLAB behaviour and reducing RAM requirements, by `Austin Hurst`_ (:gh:`72`)
+- Fixed a bug in :meth:`NoisyChannels.find_bad_by_correlation` that prevented it from being able to handle channels with dropouts (intermittent flat regions), by `Austin Hurst`_ (:gh:`81`).
 
 API
 ~~~

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -382,7 +382,7 @@ class NoisyChannels:
                     np.isnan(channel_correlation[i, j]) or np.isnan(noiselevels[i, j])
                 )
                 if drop[i, j] == 1:
-                    channel_deviations[i, j] = 0
+                    channel_correlation[i, j] = 0
                     noiselevels[i, j] = 0
         maximum_correlations[self.channels_interpolate, :] = np.transpose(
             channel_correlation

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -366,15 +366,17 @@ class NoisyChannels:
         for k in range(0, w_correlation):
             eeg_portion = np.transpose(np.squeeze(EEG_new_win[:, :, k]))
             data_portion = np.transpose(np.squeeze(data_win[:, :, k]))
-            window_correlation = np.corrcoef(np.transpose(eeg_portion))
+            with np.errstate(invalid='ignore'):  # suppress divide-by-zero warnings
+                window_correlation = np.corrcoef(np.transpose(eeg_portion))
             abs_corr = np.abs(
                 np.subtract(window_correlation, np.diag(np.diag(window_correlation)))
             )
             channel_correlation[k, :] = _mat_quantile(abs_corr, 0.98, axis=0)
-            noiselevels[k, :] = np.divide(
-                robust.mad(np.subtract(data_portion, eeg_portion), c=1),
-                robust.mad(eeg_portion, c=1),
-            )
+            with np.errstate(invalid='ignore'):  # suppress divide-by-zero warnings
+                noiselevels[k, :] = np.divide(
+                    robust.mad(np.subtract(data_portion, eeg_portion), c=1),
+                    robust.mad(eeg_portion, c=1),
+                )
             channel_deviations[k, :] = 0.7413 * _mat_iqr(data_portion, axis=0)
         for i in range(0, w_correlation):
             for j in range(0, self.new_dimensions[0]):

--- a/pyprep/utils.py
+++ b/pyprep/utils.py
@@ -5,7 +5,6 @@ from cmath import sqrt
 import mne
 import numpy as np
 import scipy.interpolate
-from scipy.stats import iqr
 from scipy.signal import firwin, lfilter, lfilter_zi
 from psutil import virtual_memory
 

--- a/pyprep/utils.py
+++ b/pyprep/utils.py
@@ -74,10 +74,27 @@ def _mat_quantile(arr, q, axis=None):
     This function mimics MATLAB's logic to produce identical results.
 
     """
+    def _mat_quantile_1d(arr, q):
+        arr = arr[~np.isnan(arr)]
+        n = len(arr)
+        if n == 0:
+            return np.NaN
+        elif n == 1:
+            return arr[0]
+        else:
+            q_adj = ((q - 0.5) * n / (n - 1)) + 0.5
+            return np.quantile(arr, np.clip(q_adj, 0, 1))
+
+    # Make sure inputs are both Numpy arrays
+    arr = np.asarray(arr)
     q = np.asarray(q, dtype=np.float64)
-    n = len(arr)
-    q_adj = ((q - 0.5) * n / (n - 1)) + 0.5
-    return np.quantile(arr, np.clip(q_adj, 0, 1), axis=axis)
+
+    if axis is not None and len(arr.shape) > 1:
+        # If an axis is specified, calculate quantiles along it
+        return np.apply_along_axis(_mat_quantile_1d, axis, arr, q)
+    else:
+        # Otherwise, calculate the quantile for the full sample
+        return _mat_quantile_1d(arr, q)
 
 
 def _mat_iqr(arr, axis=None):
@@ -103,10 +120,7 @@ def _mat_iqr(arr, axis=None):
     See notes for :func:`utils._mat_quantile`.
 
     """
-    iqr_q = np.asarray([25, 75], dtype=np.float64)
-    n = len(arr)
-    iqr_adj = ((iqr_q - 50) * n / (n - 1)) + 50
-    return iqr(arr, rng=np.clip(iqr_adj, 0, 100), axis=axis)
+    return _mat_quantile(arr, 0.75, axis) - _mat_quantile(arr, 0.25, axis)
 
 
 def _eeglab_create_highpass(cutoff, srate):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -71,6 +71,10 @@ def test_mat_quantile_iqr():
     iqr_actual = _mat_iqr(tst_nan, axis=0)
     assert all(np.isclose(iqr_expected, iqr_actual, atol=0.001))
 
+    # Test quantile behaviour in special cases
+    assert _mat_quantile([0.3], 0.98) == 0.3
+    assert np.isnan(_mat_quantile([], 0.98))
+
 
 def test_get_random_subset():
     """Test the function for getting random channel subsets."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,6 +33,11 @@ def test_mat_quantile_iqr():
        quantile(tst, 0.98);
        iqr(tst);
 
+       % Add NaNs to input and re-test
+       tst(1, :) = nan;
+       quantile(tst, 0.98);
+       iqr(tst);
+
     """
     # Generate test data
     np.random.seed(435656)
@@ -48,6 +53,22 @@ def test_mat_quantile_iqr():
 
     # Test IQR equivalence with MATLAB
     iqr_actual = _mat_iqr(tst, axis=0)
+    assert all(np.isclose(iqr_expected, iqr_actual, atol=0.001))
+
+    # Add NaNs to test data
+    tst_nan = tst.copy()
+    tst_nan[0, :] = np.NaN
+
+    # Create arrays containing MATLAB results for NaN test case
+    quantile_expected = np.asarray([0.9712, 0.9880, 0.9807])
+    iqr_expected = np.asarray([0.4764, 0.5188, 0.5044])
+
+    # Test quantile equivalence with MATLAB for array with NaN
+    quantile_actual = _mat_quantile(tst_nan, 0.98, axis=0)
+    assert all(np.isclose(quantile_expected, quantile_actual, atol=0.001))
+
+    # Test IQR equivalence with MATLAB for array with NaN
+    iqr_actual = _mat_iqr(tst_nan, axis=0)
     assert all(np.isclose(iqr_expected, iqr_actual, atol=0.001))
 
 


### PR DESCRIPTION
<!--Thanks for contributing-->
<!--If this is your first time, please make sure to read the contributing guideline-->
<!--https://github.com/sappelhoff/pyprep/blob/master/.github/CONTRIBUTING.md-->

# PR Description

Closes #80. Because Numpy's quantile function handles NaN values differently than MATLAB, finding bad-by-correlation channels in `NoisyChannels` broke completely if there were any correlation windows where a channel had a flat signal. Also, the code that was meant to replace NaN correlation values with zeros was accidentally doing so in the wrong matrix. Both of these are fixed by this PR!

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [x] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [whats_new.rst][whats-new-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[whats-new-file]: https://github.com/sappelhoff/pyprep/blob/master/docs/whats_new.rst
