### PR TITLE
Refactor & improved documentation of NoisyChannels

### DIFF
--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -3,11 +3,10 @@ import mne
 import numpy as np
 from mne.utils import check_random_state
 from scipy import signal
-from statsmodels import robust
 
 from pyprep.ransac import find_bad_by_ransac
 from pyprep.removeTrend import removeTrend
-from pyprep.utils import _mat_iqr, _mat_quantile, filter_design
+from pyprep.utils import _mat_iqr, _mat_quantile, madmed, filter_design
 
 
 class NoisyChannels:
@@ -215,7 +214,7 @@ class NoisyChannels:
 
         # Detect channels with flat or extremely weak signals
         FLAT_THRESHOLD = 1e-15  # corresponds to 10e-10 µV in MATLAB PREP
-        flat_by_mad = robust.mad(EEGData, axis=1, c=1) < FLAT_THRESHOLD
+        flat_by_mad = madmed(EEGData, axis=1) < FLAT_THRESHOLD
         flat_by_stdev = np.std(EEGData, axis=1) < FLAT_THRESHOLD
         flat_channel_mask = flat_by_mad | flat_by_stdev
         flat_channels = self.ch_names_original[flat_channel_mask]
@@ -302,8 +301,8 @@ class NoisyChannels:
         # < 50 Hz amplitude for each channel and get robust z-scores of values
         if self.sample_rate > 100:
             noisiness = np.divide(
-                robust.mad(self.EEGData - self.EEGFiltered, c=1, axis=1),
-                robust.mad(self.EEGFiltered, c=1, axis=1),
+                madmed(self.EEGData - self.EEGFiltered,  axis=1),
+                madmed(self.EEGFiltered, axis=1),
             )
             noise_median = np.nanmedian(noisiness)
             noise_sd = np.median(np.abs(noisiness - noise_median)) * MAD_TO_SD
@@ -386,7 +385,7 @@ class NoisyChannels:
             channel_deviations[w, usable] = _mat_iqr(eeg_raw, axis=1) * IQR_TO_SD
 
             # Check for any channel dropouts (flat signal) within the window
-            eeg_amplitude = robust.mad(eeg_filtered, c=1, axis=1)
+            eeg_amplitude = madmed(eeg_filtered, axis=1)
             dropout[w, usable] = eeg_amplitude == 0
 
             # Exclude any dropout chans from further calculations (avoids div-by-zero)
@@ -396,7 +395,7 @@ class NoisyChannels:
             eeg_amplitude = eeg_amplitude[eeg_amplitude > 0]
 
             # Get high-frequency noise ratios for the window
-            high_freq_amplitude = robust.mad(eeg_raw - eeg_filtered, c=1, axis=1)
+            high_freq_amplitude = madmed(eeg_raw - eeg_filtered, axis=1)
             noiselevels[w, usable] = high_freq_amplitude / eeg_amplitude
 
             # Get inter-channel correlations for the window

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -493,6 +493,12 @@ class NoisyChannels:
         This method is a wrapper for the :func:`~ransac.find_bad_by_ransac`
         function.
 
+        .. warning:: For optimal performance, RANSAC requires that channels bad by
+                     deviation, correlation, and/or dropout have already been
+                     flagged. Otherwise RANSAC will attempt to use those channels
+                     when making signal predictions, decreasing accuracy and thus
+                     increasing the likelihood of false positives.
+
         Parameters
         ----------
         n_samples : int, optional

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -255,6 +255,7 @@ class NoisyChannels:
 
         """
         IQR_TO_SD = 0.7413  # Scales units of IQR to units of SD, assuming normality
+        # Reference: https://stat.ethz.ch/R-manual/R-devel/library/stats/html/IQR.html
 
         # Get channel amplitudes and the median / robust SD of those amplitudes
         chan_amplitudes = _mat_iqr(self.EEGData, axis=1) * IQR_TO_SD
@@ -300,6 +301,7 @@ class NoisyChannels:
 
         """
         MAD_TO_SD = 1.4826  # Scales units of MAD to units of SD, assuming normality
+        # Reference: https://stat.ethz.ch/R-manual/R-devel/library/stats/html/mad.html
 
         if self.EEGFiltered is None:
             self.EEGFiltered = self._get_filtered_data()
@@ -370,6 +372,7 @@ class NoisyChannels:
 
         """
         IQR_TO_SD = 0.7413  # Scales units of IQR to units of SD, assuming normality
+        # Reference: https://stat.ethz.ch/R-manual/R-devel/library/stats/html/IQR.html
 
         if self.EEGFiltered is None:
             self.EEGFiltered = self._get_filtered_data()

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -132,47 +132,28 @@ class NoisyChannels:
             category is printed. Defaults to ``False``.
 
         """
-        bads = (
-            self.bad_by_nan
-            + self.bad_by_flat
-            + self.bad_by_deviation
-            + self.bad_by_hf_noise
-            + self.bad_by_SNR
-            + self.bad_by_correlation
-            + self.bad_by_dropout
-            + self.bad_by_ransac
-        )
-        bads = list(set(bads))
+        bads = {
+            "n/a": self.bad_by_nan,
+            "flat": self.bad_by_flat,
+            "deviation": self.bad_by_deviation,
+            "hf noise": self.bad_by_hf_noise,
+            "correl": self.bad_by_correlation,
+            "SNR": self.bad_by_SNR,
+            "dropout": self.bad_by_dropout,
+            "RANSAC": self.bad_by_ransac
+        }
+
+        all_bads = set()
+        for bad_chs in bads.values():
+            all_bads.update(bad_chs)
 
         if verbose:
-            print("Found {} uniquely bad channels.".format(len(bads)))
-            print("\n{} by n/a: {}".format(len(self.bad_by_nan), self.bad_by_nan))
-            print("\n{} by flat: {}".format(len(self.bad_by_flat), self.bad_by_flat))
-            print(
-                "\n{} by deviation: {}".format(
-                    len(self.bad_by_deviation), self.bad_by_deviation
-                )
-            )
-            print(
-                "\n{} by hf noise: {}".format(
-                    len(self.bad_by_hf_noise), self.bad_by_hf_noise
-                )
-            )
-            print(
-                "\n{} by correl: {}".format(
-                    len(self.bad_by_correlation), self.bad_by_correlation
-                )
-            )
-            print("\n{} by SNR {}".format(len(self.bad_by_SNR), self.bad_by_SNR))
-            print(
-                "\n{} by dropout: {}".format(
-                    len(self.bad_by_dropout), self.bad_by_dropout
-                )
-            )
-            print(
-                "\n{} by ransac: {}".format(len(self.bad_by_ransac), self.bad_by_ransac)
-            )
-        return bads
+            out = "Found {} uniquely bad channels:\n".format(len(all_bads))
+            for bad_type, bad_chs in bads.items():
+                out += "\n{} by {}: {}\n".format(len(bad_chs), bad_type, bad_chs)
+            print(out)
+
+        return list(all_bads)
 
     def find_all_bads(self, ransac=True, channel_wise=False, max_chunk_size=None):
         """Call all the functions to detect bad channels.

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -6,7 +6,7 @@ from scipy import signal
 
 from pyprep.ransac import find_bad_by_ransac
 from pyprep.removeTrend import removeTrend
-from pyprep.utils import _mat_iqr, _mat_quantile, madmed, filter_design
+from pyprep.utils import _mat_iqr, _mat_quantile, filter_design, madmed
 
 
 class NoisyChannels:
@@ -264,7 +264,7 @@ class NoisyChannels:
         amplitude_zscore = np.zeros(self.n_chans_original)
         amplitude_zscore[self.usable_idx] = (chan_amplitudes - amp_median) / amp_sd
 
-        # Flag channels with variance that deviates excessively from the median
+        # Flag channels with amplitudes that deviate excessively from the median
         abnormal_amplitude = np.abs(amplitude_zscore) > deviation_threshold
         deviation_channel_mask = np.isnan(amplitude_zscore) | abnormal_amplitude
 

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -135,6 +135,11 @@ class NoisyChannels:
             If ``True``, a summary of the channels currently flagged as by bad per
             category is printed. Defaults to ``False``.
 
+        Returns
+        -------
+        bads : list
+            THe names of all bad channels detected by any method so far.
+
         """
         bads = {
             "n/a": self.bad_by_nan,
@@ -144,7 +149,7 @@ class NoisyChannels:
             "correl": self.bad_by_correlation,
             "SNR": self.bad_by_SNR,
             "dropout": self.bad_by_dropout,
-            "RANSAC": self.bad_by_ransac
+            "RANSAC": self.bad_by_ransac,
         }
 
         all_bads = set()
@@ -270,7 +275,7 @@ class NoisyChannels:
             {
                 "median_channel_amplitude": amp_median,
                 "channel_amplitude_sd": amp_sd,
-                "robust_channel_deviations": amplitude_zscore
+                "robust_channel_deviations": amplitude_zscore,
             }
         )
 
@@ -306,7 +311,7 @@ class NoisyChannels:
         # < 50 Hz amplitude for each channel and get robust z-scores of values
         if self.sample_rate > 100:
             noisiness = np.divide(
-                madmed(self.EEGData - self.EEGFiltered,  axis=1),
+                madmed(self.EEGData - self.EEGFiltered, axis=1),
                 madmed(self.EEGFiltered, axis=1),
             )
             noise_median = np.nanmedian(noisiness)

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -157,9 +157,9 @@ class NoisyChannels:
             all_bads.update(bad_chs)
 
         if verbose:
-            out = "Found {} uniquely bad channels:\n".format(len(all_bads))
+            out = f"Found {len(all_bads)} uniquely bad channels:\n"
             for bad_type, bad_chs in bads.items():
-                out += "\n{} by {}: {}\n".format(len(bad_chs), bad_type, bad_chs)
+                out += f"\n{len(bad_chs)} by {bad_type}: {bad_chs}\n"
             print(out)
 
         return list(all_bads)
@@ -195,6 +195,7 @@ class NoisyChannels:
             effect. Defaults to ``None``.
 
         """
+        # NOTE: Bad-by-NaN/flat is already run during init, no need to re-run here
         self.find_bad_by_deviation()
         self.find_bad_by_hfnoise()
         self.find_bad_by_correlation()
@@ -250,7 +251,7 @@ class NoisyChannels:
         ----------
         deviation_threshold : float, optional
             The minimum absolute z-score of a channel for it to be considered
-            bad-by-deviation. Defaults to 5.0.
+            bad-by-deviation. Defaults to ``5.0``.
 
         """
         IQR_TO_SD = 0.7413  # Scales units of IQR to units of SD, assuming normality
@@ -295,7 +296,7 @@ class NoisyChannels:
         ----------
         HF_zscore_threshold : float, optional
             The minimum noisiness z-score of a channel for it to be considered
-            bad-by-high-frequency-noise. Defaults to 5.0.
+            bad-by-high-frequency-noise. Defaults to ``5.0``.
 
         """
         MAD_TO_SD = 1.4826  # Scales units of MAD to units of SD, assuming normality

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -15,6 +15,8 @@ class NoisyChannels:
     This class provides a number of methods for detecting bad channels across a
     full-session EEG recording. Specifically, this class implements all of the
     noisy channel detection methods used in the PREP pipeline, as described in [1]_.
+    The detection methods in this class can be run independently, or can be run
+    all at once using the :meth:`~.find_all_bads` method.
 
     At present, only EEG channels are supported and any non-EEG channels in the
     provided data will be ignored.
@@ -123,6 +125,9 @@ class NoisyChannels:
 
     def get_bads(self, verbose=False):
         """Get a list of all channels currently flagged as bad.
+
+        Note that this method does not perform any bad channel detection itself,
+        and only reports channels already detected as bad by other methods.
 
         Parameters
         ----------

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -462,9 +462,9 @@ class NoisyChannels:
     def find_bad_by_ransac(
         self,
         n_samples=50,
-        fraction_good=0.25,
+        sample_prop=0.25,
         corr_thresh=0.75,
-        fraction_bad=0.4,
+        frac_bad=0.4,
         corr_window_secs=5.0,
         channel_wise=False,
         max_chunk_size=None,
@@ -508,7 +508,7 @@ class NoisyChannels:
             The minimum predicted vs. actual signal correlation for a channel to
             be considered good within a given RANSAC window. Defaults
             to ``0.75``.
-        fraction_bad : float, optional
+        frac_bad : float, optional
             The minimum fraction of bad (i.e., below-threshold) RANSAC windows
             for a channel to be considered bad-by-RANSAC. Defaults to ``0.4``.
         corr_window_secs : float, optional
@@ -553,9 +553,9 @@ class NoisyChannels:
             self.raw_mne._get_channel_positions()[self.usable_idx, :],
             exclude_from_ransac,
             n_samples,
-            fraction_good,
+            sample_prop,
             corr_thresh,
-            fraction_bad,
+            frac_bad,
             corr_window_secs,
             channel_wise,
             max_chunk_size,

--- a/pyprep/ransac.py
+++ b/pyprep/ransac.py
@@ -8,9 +8,9 @@ from pyprep.utils import (
     _correlate_arrays,
     _get_random_subset,
     _mat_round,
-    print_progress,
-    split_list,
-    verify_free_ram,
+    _print_progress,
+    _split_list,
+    _verify_free_ram,
 )
 
 
@@ -110,7 +110,7 @@ def find_bad_by_ransac(
 
     References
     ----------
-    .. [1] Fischler, M.A., Bolles, R.C. (1981). Random rample consensus: A
+    .. [1] Fischler, M.A., Bolles, R.C. (1981). Random sample consensus: A
         Paradigm for Model Fitting with Applications to Image Analysis and
         Automated Cartography. Communications of the ACM, 24, 381-395
     .. [2] Jas, M., Engemann, D.A., Bekhti, Y., Raimondo, F., Gramfort, A.
@@ -148,10 +148,10 @@ def find_bad_by_ransac(
     # Before running, make sure we have enough memory when using the
     # smallest possible chunk size
     if channel_wise:
-        verify_free_ram(data, n_samples, 1)
+        _verify_free_ram(data, n_samples, 1)
     else:
         window_size = int(sample_rate * corr_window_secs)
-        verify_free_ram(data[:, :window_size], n_samples, n_chans_good)
+        _verify_free_ram(data[:, :window_size], n_samples, n_chans_good)
 
     # Generate random channel picks for each RANSAC sample
     random_ch_picks = []
@@ -207,7 +207,7 @@ def find_bad_by_ransac(
     # If not using window-wise RANSAC, do channel-wise RANSAC
     while mem_error and channel_wise:
         try:
-            channel_chunks = split_list(job, chunk_size)
+            channel_chunks = _split_list(job, chunk_size)
             total_chunks = len(channel_chunks)
             current = 1
             for chunk in channel_chunks:
@@ -332,7 +332,7 @@ def _ransac_by_window(data, interpolation_mats, win_size, win_count, matlab_stri
     for window in range(win_count):
 
         # Print RANSAC progress in 10% increments
-        print_progress(window + 1, win_count, every=0.1)
+        _print_progress(window + 1, win_count, every=0.1)
 
         # Get the current window of EEG data
         start = window * win_size
@@ -509,7 +509,7 @@ def _predict_median_signals_channelwise(
     n_timepts = data.shape[1]
 
     # Before running, make sure we have enough memory
-    verify_free_ram(data, ransac_samples, chunk_size)
+    _verify_free_ram(data, ransac_samples, chunk_size)
 
     # Memory seems to be fine ...
     # Make the predictions

--- a/pyprep/ransac.py
+++ b/pyprep/ransac.py
@@ -21,9 +21,9 @@ def find_bad_by_ransac(
     chn_pos,
     exclude,
     n_samples=50,
-    fraction_good=0.25,
+    sample_prop=0.25,
     corr_thresh=0.75,
-    fraction_bad=0.4,
+    frac_bad=0.4,
     corr_window_secs=5.0,
     channel_wise=False,
     max_chunk_size=None,
@@ -69,7 +69,7 @@ def find_bad_by_ransac(
     corr_thresh : float, optional
         The minimum predicted vs. actual signal correlation for a channel to
         be considered good within a given RANSAC window. Defaults to ``0.75``.
-    fraction_bad : float, optional
+    frac_bad : float, optional
         The minimum fraction of bad (i.e., below-threshold) RANSAC windows for a
         channel to be considered bad-by-RANSAC. Defaults to ``0.4``.
     corr_window_secs : float, optional
@@ -133,13 +133,13 @@ def find_bad_by_ransac(
     # Check if we have enough remaining channels
     # after exclusion of bad channels
     n_chans = data.shape[0]
-    n_pred_chns = int(np.around(fraction_good * n_chans))
+    n_pred_chns = int(np.around(sample_prop * n_chans))
 
     if n_pred_chns <= 3:
-        sample_pct = int(fraction_good * 100)
+        sample_pct = int(sample_prop * 100)
         e = "Too few channels in the original data to reliably perform RANSAC "
         e += "(minimum {0} for a sample size of {1}%)."
-        raise IOError(e.format(int(np.floor(4.0 / fraction_good)), sample_pct))
+        raise IOError(e.format(int(np.floor(4.0 / sample_prop)), sample_pct))
     elif n_chans_good < (n_pred_chns + 1):
         e = "Too many noisy channels in the data to reliably perform RANSAC "
         e += "(only {0} good channels remaining, need at least {1})."
@@ -247,7 +247,7 @@ def find_bad_by_ransac(
     frac_bad_corr_windows = np.mean(thresholded_correlations, axis=0)
 
     # find the corresponding channel names and return
-    bad_ransac_channels_idx = np.argwhere(frac_bad_corr_windows > fraction_bad)
+    bad_ransac_channels_idx = np.argwhere(frac_bad_corr_windows > frac_bad)
     bad_ransac_channels_name = complete_chn_labs[bad_ransac_channels_idx.astype(int)]
     bad_by_ransac = [i[0] for i in bad_ransac_channels_name]
     print("\nRANSAC done!")

--- a/pyprep/utils.py
+++ b/pyprep/utils.py
@@ -17,10 +17,6 @@ def _set_diff(list1, list2):
     return list(set(list1) - set(list2))
 
 
-def _intersect(list1, list2):
-    return list(set(list1).intersection(set(list2)))
-
-
 def _mat_round(x):
     """Round a number to the nearest whole number.
 

--- a/pyprep/utils.py
+++ b/pyprep/utils.py
@@ -327,7 +327,7 @@ def _mad(x, axis=None):
     Parameters
     ----------
     x : np.ndarray
-        Input array containing the values to summarize.
+        A 1-D or 2-D numeric array to summarize.
     axis : {int, tuple of int, None}, optional
         Axis along which MADs should be calculated. If ``None``, the MAD will
         be calculated for the full input array. Defaults to ``None``.
@@ -340,10 +340,18 @@ def _mad(x, axis=None):
         the MAD for each index along the specified axis.
 
     """
+    # Ensure array is either 1D or 2D
+    x = np.asarray(x)
+    if x.ndim > 2:
+        e = "Only 1D and 2D arrays are supported (input has {0} dimensions)"
+        raise ValueError(e.format(x.ndim))
+
+    # Calculate the median absolute deviation from the median
     med = np.median(x, axis=axis)
     if axis == 1:
         med = med.reshape(-1, 1)  # Transposes array to allow subtraction below
     mad = np.median(np.abs(x - med), axis=axis)
+
     return mad
 
 

--- a/pyprep/utils.py
+++ b/pyprep/utils.py
@@ -2,7 +2,6 @@
 import math
 from cmath import sqrt
 
-import mne
 import numpy as np
 import scipy.interpolate
 from psutil import virtual_memory

--- a/pyprep/utils.py
+++ b/pyprep/utils.py
@@ -321,7 +321,7 @@ def _correlate_arrays(a, b, matlab_strict=False):
         return np.diag(np.corrcoef(a, b)[:n_chan, n_chan:])
 
 
-def madmed(x, axis=None):
+def _mad(x, axis=None):
     """Calculate median absolute deviations from the median (MAD) for an array.
 
     Parameters
@@ -343,10 +343,11 @@ def madmed(x, axis=None):
     med = np.median(x, axis=axis)
     if axis == 1:
         med = med.reshape(-1, 1)  # Transposes array to allow subtraction below
-    return np.median(np.abs(x - med), axis=axis)
+    mad = np.median(np.abs(x - med), axis=axis)
+    return mad
 
 
-def filter_design(N_order, amp, freq):
+def _filter_design(N_order, amp, freq):
     """Create FIR low-pass filter for EEG data using frequency sampling method.
 
     Parameters
@@ -394,7 +395,7 @@ def filter_design(N_order, amp, freq):
     return kernel
 
 
-def split_list(mylist, chunk_size):
+def _split_list(mylist, chunk_size):
     """Split list in chunks.
 
     Parameters
@@ -416,7 +417,7 @@ def split_list(mylist, chunk_size):
     ]
 
 
-def print_progress(current, end, start=None, stepsize=1, every=0.1):
+def _print_progress(current, end, start=None, stepsize=1, every=0.1):
     """Print the current progress in a loop.
 
     Parameters
@@ -454,70 +455,7 @@ def print_progress(current, end, start=None, stepsize=1, every=0.1):
             print("{0}%...".format(int(pct)), end=" ", flush=True)
 
 
-def make_random_mne_object(
-    ch_names,
-    ch_types,
-    times,
-    sfreq,
-    n_freq_comps=5,
-    freq_range=[10, 60],
-    scale=1e-6,
-    RNG=np.random.RandomState(1337),
-):
-    """Make a random MNE object to use for testing.
-
-    Parameters
-    ----------
-    ch_names : list
-        names of channels
-    ch_types : list
-        types of channels
-    times : np.ndarray, shape (1,)
-        Time vector to use.
-    sfreq : float
-        Sampling frequency associated with the time vector.
-    n_freq_comps : int
-        Number of signal components summed to make a signal.
-    freq_range : list, len==2
-        Signals will contain freqs from this range.
-    scale : float
-        Scaling factor applied to the signal in volts. For example 1e-6 to
-        get microvolts.
-    RNG : np.random.RandomState
-        Random state seed.
-
-    Returns
-    -------
-    raw : mne.io.Raw
-        The mne object for performing the tests.
-    n_freq_comps : int
-        Number of random frequency components to introduce.
-    freq_range : tuple
-        The low (`freq_range[0]`) and high (`freq_range[1]`) endpoints of
-        a frequency range from which random draws will be made to
-        introduce frequency components in the test data.
-    """
-    n_chans = len(ch_names)
-    signal_len = times.shape[0]
-    # Make a random signal
-    signal = np.zeros((n_chans, signal_len))
-    low = freq_range[0]
-    high = freq_range[1]
-    for chan in range(n_chans):
-        # Each channel signal is a sum of random freq sine waves
-        for freq_i in range(n_freq_comps):
-            freq = RNG.randint(low, high, signal_len)
-            signal[chan, :] += np.sin(2 * np.pi * times * freq)
-
-    signal *= scale  # scale
-
-    # Make mne object
-    info = mne.create_info(ch_names=ch_names, sfreq=sfreq, ch_types=ch_types)
-    raw = mne.io.RawArray(signal, info)
-    return raw, n_freq_comps, freq_range
-
-
-def verify_free_ram(data, n_samples, n_channels, max_prop=0.95):
+def _verify_free_ram(data, n_samples, n_channels, max_prop=0.95):
     """Check if enough memory is free to run RANSAC with the given parameters.
 
     Parameters

--- a/pyprep/utils.py
+++ b/pyprep/utils.py
@@ -301,7 +301,7 @@ def _correlate_arrays(a, b, matlab_strict=False):
     Notes
     -----
     In MATLAB PREP, RANSAC channel predictions are correlated with actual data
-    using a non-standard method: essentialy, it uses the standard Pearson
+    using a non-standard method: essentially, it uses the standard Pearson
     correlation formula but without subtracting the channel means from each channel
     before calculating sums of squares, i.e.,::
 
@@ -323,6 +323,31 @@ def _correlate_arrays(a, b, matlab_strict=False):
     else:
         n_chan = a.shape[0]
         return np.diag(np.corrcoef(a, b)[:n_chan, n_chan:])
+
+
+def madmed(x, axis=None):
+    """Calculate median absolute deviations from the median (MAD) for an array.
+
+    Parameters
+    ----------
+    x : np.ndarray
+        Input array containing the values to summarize.
+    axis : {int, tuple of int, None}, optional
+        Axis along which MADs should be calculated. If ``None``, the MAD will
+        be calculated for the full input array. Defaults to ``None``.
+
+    Returns
+    -------
+    mad : scalar or np.ndarray
+        If no axis is specified, returns the MAD for the full input array as a
+        single numeric value. Otherwise, returns an ``np.ndarray`` containing
+        the MAD for each index along the specified axis.
+
+    """
+    med = np.median(x, axis=axis)
+    if axis == 1:
+        med = med.reshape(-1, 1)  # Transposes array to allow subtraction below
+    return np.median(np.abs(x - med), axis=axis)
 
 
 def filter_design(N_order, amp, freq):

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ python_requires = >= 3.7
 install_requires =
   numpy >= 1.14.1
   scipy >= 1.0.0
-  statsmodels >= 0.8.0
   mne >= 0.20.0
   psutil >= 5.4.3
 packages = find:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Configure tests."""
 import mne
+import numpy as np
 import pytest
 from mne.datasets import eegbci
 
@@ -66,3 +67,66 @@ def raw_clean(montage):
     raw.set_montage(montage)
 
     return raw
+
+
+def make_random_mne_object(
+    ch_names,
+    ch_types,
+    times,
+    sfreq,
+    n_freq_comps=5,
+    freq_range=[10, 60],
+    scale=1e-6,
+    RNG=np.random.RandomState(1337),
+):
+    """Make a random MNE object to use for testing.
+
+    Parameters
+    ----------
+    ch_names : list
+        names of channels
+    ch_types : list
+        types of channels
+    times : np.ndarray, shape (1,)
+        Time vector to use.
+    sfreq : float
+        Sampling frequency associated with the time vector.
+    n_freq_comps : int
+        Number of signal components summed to make a signal.
+    freq_range : list, len==2
+        Signals will contain freqs from this range.
+    scale : float
+        Scaling factor applied to the signal in volts. For example 1e-6 to
+        get microvolts.
+    RNG : np.random.RandomState
+        Random state seed.
+
+    Returns
+    -------
+    raw : mne.io.Raw
+        The mne object for performing the tests.
+    n_freq_comps : int
+        Number of random frequency components to introduce.
+    freq_range : tuple
+        The low (`freq_range[0]`) and high (`freq_range[1]`) endpoints of
+        a frequency range from which random draws will be made to
+        introduce frequency components in the test data.
+    """
+    n_chans = len(ch_names)
+    signal_len = times.shape[0]
+    # Make a random signal
+    signal = np.zeros((n_chans, signal_len))
+    low = freq_range[0]
+    high = freq_range[1]
+    for chan in range(n_chans):
+        # Each channel signal is a sum of random freq sine waves
+        for freq_i in range(n_freq_comps):
+            freq = RNG.randint(low, high, signal_len)
+            signal[chan, :] += np.sin(2 * np.pi * times * freq)
+
+    signal *= scale  # scale
+
+    # Make mne object
+    info = mne.create_info(ch_names=ch_names, sfreq=sfreq, ch_types=ch_types)
+    raw = mne.io.RawArray(signal, info)
+    return raw, n_freq_comps, freq_range

--- a/tests/test_matprep_compare.py
+++ b/tests/test_matprep_compare.py
@@ -171,26 +171,26 @@ class TestCompareNoisyChannels(object):
         # Gather PyPREP deviation info and MATLAB equivalents
         mat = matprep_noisy
         matprep_info = {
-            "median_channel_deviation": mat["channelDeviationMedian"],
-            "channel_deviation_sd": mat["channelDeviationSD"],
+            "median_channel_amplitude": mat["channelDeviationMedian"],
+            "channel_amplitude_sd": mat["channelDeviationSD"],
             "robust_channel_deviations": mat["robustChannelDeviation"],
-            "channel_deviations": mat["channelDeviations"],
+            "channel_amplitudes": mat["channelDeviations"],
         }
         pyprep_info = pyprep_noisy._extra_info["bad_by_deviation"]
 
-        # Compare overall medians and SDs for channel deviations
-        median_dev = "median_channel_deviation"
-        dev_sd = "channel_deviation_sd"
-        assert np.isclose(pyprep_info[median_dev] * 1e6, matprep_info[median_dev])
-        assert np.isclose(pyprep_info[dev_sd] * 1e6, matprep_info[dev_sd])
+        # Compare overall medians and SDs for channel amplitudes
+        median_amp = "median_channel_amplitude"
+        amp_sd = "channel_amplitude_sd"
+        assert np.isclose(pyprep_info[median_amp] * 1e6, matprep_info[median_amp])
+        assert np.isclose(pyprep_info[amp_sd] * 1e6, matprep_info[amp_sd])
 
-        # Compare robust deviations across channels
+        # Compare robust amplitude deviations across channels
         dev_by_chan = "robust_channel_deviations"
         assert np.allclose(pyprep_info[dev_by_chan], matprep_info[dev_by_chan])
 
-        # Compare windows of channel deviations across recording
-        chan_devs = "channel_deviations"
-        assert np.allclose(pyprep_info[chan_devs] * 1e6, matprep_info[chan_devs].T)
+        # Compare windows of channel amplitudes across recording
+        chan_amps = "channel_amplitudes"
+        assert np.allclose(pyprep_info[chan_amps] * 1e6, matprep_info[chan_amps].T)
 
         # Compare names of bad-by-deviation channels
         assert pyprep_noisy.bad_by_deviation == matprep_noisy["bads"]["by_deviation"]

--- a/tests/test_prep_pipeline.py
+++ b/tests/test_prep_pipeline.py
@@ -6,7 +6,8 @@ import pytest
 import scipy.io as sio
 
 from pyprep.prep_pipeline import PrepPipeline
-from pyprep.utils import make_random_mne_object
+
+from .conftest import make_random_mne_object
 
 
 @pytest.mark.usefixtures("raw", "montage")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -165,6 +165,11 @@ def test_mad():
     assert all(np.equal(_mad(tst.T, axis=0), expected))
     assert _mad(tst) == 28  # Matches robust.mad from statsmodels
 
+    # Test exception with > 2-D arrays
+    tst = np.random.rand(3, 3, 3)
+    with pytest.raises(ValueError):
+        _mad(tst, axis=0)
+
 
 def test_print_progress(capsys):
     """Test the function for printing progress updates within a loop."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -157,11 +157,7 @@ def test_eeglab_create_highpass():
 def test_madmed():
     """Test the median absolute deviation from the median (MAD) function."""
     # Generate test data
-    tst = np.array([
-        [1, 2, 3, 4, 8],
-        [80, 10, 20, 30, 40],
-        [100, 200, 800, 300, 400]
-    ])
+    tst = np.array([[1, 2, 3, 4, 8], [80, 10, 20, 30, 40], [100, 200, 800, 300, 400]])
     expected = np.asarray([1, 10, 100])
 
     # Compare output to expected results

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,7 @@ from pyprep.utils import (
     _mat_iqr,
     _mat_quantile,
     _mat_round,
+    madmed,
     print_progress,
 )
 
@@ -138,19 +139,35 @@ def test_eeglab_create_highpass():
     NOTE: EEGLAB values were obtained using breakpoints in ``pop_eegfiltnew``,
     since filter creation and data filtering are both done in the same function.
     Values here are first 4 values of the array ``b`` which contains the FIR
-    filter coefficents used by the function.
+    filter coefficients used by the function.
 
     """
-    # Compare initial FIR filter coefficents with EEGLAB
+    # Compare initial FIR filter coefficients with EEGLAB
     expected_vals = [5.3691e-5, 5.4165e-5, 5.4651e-5, 5.5149e-5]
     actual_vals = _eeglab_create_highpass(cutoff=1.0, srate=256)[:4]
     assert all(np.isclose(expected_vals, actual_vals, atol=0.001))
 
-    # Compare middle FIR filter coefficent with EEGLAB
+    # Compare middle FIR filter coefficient with EEGLAB
     vals = _eeglab_create_highpass(cutoff=1.0, srate=256)
     expected_val = 0.9961
     actual_val = vals[len(vals) // 2]
     assert np.isclose(expected_val, actual_val, atol=0.001)
+
+
+def test_madmed():
+    """Test the median absolute deviation from the median (MAD) function."""
+    # Generate test data
+    tst = np.array([
+        [1, 2, 3, 4, 8],
+        [80, 10, 20, 30, 40],
+        [100, 200, 800, 300, 400]
+    ])
+    expected = np.asarray([1, 10, 100])
+
+    # Compare output to expected results
+    assert all(np.equal(madmed(tst, axis=1), expected))
+    assert all(np.equal(madmed(tst.T, axis=0), expected))
+    assert madmed(tst) == 28  # Matches robust.mad from statsmodels
 
 
 def test_print_progress(capsys):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,11 +7,11 @@ from pyprep.utils import (
     _correlate_arrays,
     _eeglab_create_highpass,
     _get_random_subset,
+    _mad,
     _mat_iqr,
     _mat_quantile,
     _mat_round,
-    madmed,
-    print_progress,
+    _print_progress,
 )
 
 
@@ -154,36 +154,36 @@ def test_eeglab_create_highpass():
     assert np.isclose(expected_val, actual_val, atol=0.001)
 
 
-def test_madmed():
+def test_mad():
     """Test the median absolute deviation from the median (MAD) function."""
     # Generate test data
     tst = np.array([[1, 2, 3, 4, 8], [80, 10, 20, 30, 40], [100, 200, 800, 300, 400]])
     expected = np.asarray([1, 10, 100])
 
     # Compare output to expected results
-    assert all(np.equal(madmed(tst, axis=1), expected))
-    assert all(np.equal(madmed(tst.T, axis=0), expected))
-    assert madmed(tst) == 28  # Matches robust.mad from statsmodels
+    assert all(np.equal(_mad(tst, axis=1), expected))
+    assert all(np.equal(_mad(tst.T, axis=0), expected))
+    assert _mad(tst) == 28  # Matches robust.mad from statsmodels
 
 
 def test_print_progress(capsys):
     """Test the function for printing progress updates within a loop."""
     # Test printing start value
-    print_progress(1, 20)
+    _print_progress(1, 20)
     captured = capsys.readouterr()
     assert captured.out == "Progress: "
 
     # Test printing end values
     iterations = 27
     for i in range(iterations):
-        print_progress(i + 1, iterations, every=0.2)
+        _print_progress(i + 1, iterations, every=0.2)
     captured = capsys.readouterr()
     assert captured.out == "Progress: 20%... 40%... 60%... 80%... 100%\n"
 
     # Test printing of updates at right times
     iterations = 176
     for i in range(iterations):
-        print_progress(i + 1, iterations)
+        _print_progress(i + 1, iterations)
         if (i + 1) == 17:
             captured = capsys.readouterr()
             assert captured.out == "Progress: "
@@ -196,7 +196,7 @@ def test_print_progress(capsys):
     iterations = 25
     start = 5
     for i in range(start, iterations + 1):
-        print_progress(i, iterations, start=start)
+        _print_progress(i, iterations, start=start)
         if i == 6:
             captured = capsys.readouterr()
             assert captured.out == "Progress: "


### PR DESCRIPTION
<!--Thanks for contributing-->
<!--If this is your first time, please make sure to read the contributing guideline-->
<!--https://github.com/sappelhoff/pyprep/blob/master/.github/CONTRIBUTING.md-->

# PR Description

This has been sitting half-done for a while now, but I've finally got this into a good draft state! This PR is a major cleanup of the code/docs for the non-RANSAC `NoisyChannels` methods, including:

- Splitting the code for each method into small, documented chunks
- Moving he code for 50 Hz bandpass filtering to its own separate private method, so that all noisy detection methods can be run independently/repeatedly without accidental re-filtering of the data, and that we ensure the data is always filtered pre-RANSAC.
- Rewriting the docstrings for the class and all the methods to better explain what they all do, now that I've mostly wrapped my head around the logic
- Implemented a simple `madmed` function in utils to replace `robust.mad` for a mild speed boost, which also removes the entire dependency of `statsmodels`
- Refactoring `find_bad_by_correlation` to avoid division-by-zero and the related warning suppression code
- Identifying and documenting some magic numbers

Some other stuff I noticed but didn't clean up yet:
- The bad window fraction threshold is `frac_bad` for the bad-by-correlation method, but is `fraction_bad` for the bad-by-RANSAC method. Should these be made consistent?
- Technically bad-by-deviation, bad-by-correlation, and bad-by-dropout channels are all supposed to be detected and excluded prior to RANSAC, but right now the code doesn't enforce this. Should we add a chunk of code to ensure those have all been run first?
- For RANSAC, the name of the argument specifying the proportion of channels to use per sample is `sample_prop` in the docstring, but `fraction_good` in the function definition. Since `fraction_good` isn't technically accurate anymore, I'm assuming I should switch to `sample_prop` throughout?

This doesn't really move us any closer to 0.4.0, but I find code cleanup like this sort of relaxing so it was nice to pick away at between other work. Also, please let me know if any of the new code or docs is unclear!

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [whats_new.rst][whats-new-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[whats-new-file]: https://github.com/sappelhoff/pyprep/blob/master/docs/whats_new.rst
