### PR TITLE
Use identical RNG state across RANSAC runs when matlab_strict enabled

### DIFF
--- a/docs/matlab_differences.rst
+++ b/docs/matlab_differences.rst
@@ -5,7 +5,7 @@
 Deliberate Differences from MATLAB PREP
 =======================================
 
-Although PyPREP aims to be a faithful reimplementaion of the original MATLAB
+Although PyPREP aims to be a faithful reimplementation of the original MATLAB
 version of PREP, there are a few places where PyPREP has deliberately chosen
 to use different defaults than the MATLAB PREP.
 
@@ -38,7 +38,7 @@ values also differ slightly (on the order of ~0.002) for RANSAC correlations.
 Because the practical differences are small and MNE's filtering is fast and
 well-tested, PyPREP defaults to using :func:`mne.filter.filter_data` for
 high-pass trend removal. However, for exact numerical compatibility, PyPREP
-has a basic re-implementaion of EEGLAB's ``pop_eegfiltnew`` in Python that
+has a basic re-implementation of EEGLAB's ``pop_eegfiltnew`` in Python that
 produces identical results to MATLAB PREP's ``removeTrend`` when
 ``matlab_strict`` is set to ``True``.
 
@@ -47,7 +47,7 @@ Differences in RANSAC
 ---------------------
 
 During the "find-bad-by-RANSAC" step of noisy channel detection (see
-:func:`~pyprep.ransac.find_bad_by_ransac`), PREP does the follwing steps to
+:func:`~pyprep.ransac.find_bad_by_ransac`), PREP does the following steps to
 identify channels that aren't well-predicted by the signals of other channels:
 
 1) Generates a bunch of random subsets of currently-good channels from the data
@@ -75,6 +75,26 @@ identify channels that aren't well-predicted by the signals of other channels:
 
 With that in mind, here are the areas where PyPREP's defaults deliberately
 differ from the original PREP implementation:
+
+
+Use of random seeds
+^^^^^^^^^^^^^^^^^^^
+
+In MATLAB PREP, the random seed used for RANSAC is always ``435656``, which is
+set just before random channel sampling occurs. This means that every run of
+RANSAC will result in identical random samples of channels given the same
+input, and will produce similar random samples of channels if a channel or two
+are removed between iterations.
+
+Conversely, PyPREP defaults to setting an initial random state for the whole
+pipeline, meaning that RANSAC's random channel picks will differ between
+consecutive runs during robust re-referencing or bad channel detection. This
+approach has the benefit of better randomness, but may also lead to more
+variability in PREP results between different seed values. More testing is
+required to determine which approach produces better results.
+
+Note that to match MATLAB PREP exactly when ``matlab_strict`` is ``True``, the
+random seed ``435656`` must be used.
 
 
 Calculation of median estimated signal
@@ -107,7 +127,7 @@ Correlation of predicted vs. actual signals
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In MATLAB PREP, RANSAC channel predictions are correlated with actual data
-in step 4 using a non-standard method: essentialy, it uses the standard Pearson
+in step 4 using a non-standard method: essentially, it uses the standard Pearson
 correlation formula but without subtracting the channel means from each channel
 before calculating sums of squares. This is done in the last line of the
 ``calculateRansacWindow`` function reproduced above:
@@ -116,7 +136,7 @@ before calculating sums of squares. This is done in the last line of the
 
    rX = sum(XX.*YY)./(sqrt(sum(XX.^2)).*sqrt(sum(YY.^2)));
 
-For readablility, here's the same formula written in Python code::
+For readability, here's the same formula written in Python code::
 
    SSxx = np.sum(xx ** 2)
    SSyy = np.sum(yy ** 2)
@@ -126,5 +146,5 @@ Because the EEG data will have already been filtered to remove slow drifts in
 baseline before RANSAC, the signals correlated by this method will already be
 roughly mean-centered. and will thus produce similar values to normal Pearson
 correlation. However, to avoid making any assumptions about the signal for any
-given channel / window, PyPREP defaults to normal earson correlation unless
+given channel / window, PyPREP defaults to normal Pearson correlation unless
 strict MATLAB equivalence is requested.

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -46,6 +46,7 @@ Changelog
 - Changed :class:`~pyprep.Reference` to exclude "bad-by-SNR" channels from initial average referencing, matching MATLAB PREP behaviour, by `Austin Hurst`_ (:gh:`78`)
 - Changed :class:`~pyprep.Reference` to only flag "unusable" channels (bad by flat, NaNs, or low SNR) from the first pass of noisy detection for permanent exclusion from the reference signal, matching MATLAB PREP behaviour, by `Austin Hurst`_ (:gh:`78`)
 - Added a framework for automated testing of PyPREP's components against their MATLAB PREP counterparts (using ``.mat`` and ``.set`` files generated with the `matprep_artifacts`_ script), helping verify that the two PREP implementations are numerically equivalent when `matlab_strict` is ``True``, by `Austin Hurst`_ (:gh:`79`)
+- Changed :class:`~pyprep.NoisyChannels` to reuse the same random state for each run of RANSAC when ``matlab_strict`` is ``True``, matching MATLAB PREP behaviour, by `Austin Hurst`_ (:gh:`89`)
 
 .. _matprep_artifacts: https://github.com/a-hurst/matprep_artifacts
 
@@ -65,6 +66,7 @@ API
 - The following methods have been moved to a new module named :mod:`~pyprep.ransac` and are now private: `NoisyChannels.ransac_correlations`, `NoisyChannels.run_ransac`, and `NoisyChannels.get_ransac_pred` methods, by `Yorguin Mantilla`_ (:gh:`51`)
 - The permissible parameters for the following methods were removed and/or reordered: `NoisyChannels.ransac_correlations`, `NoisyChannels.run_ransac`, and `NoisyChannels.get_ransac_pred` methods, by `Austin Hurst`_ and `Yorguin Mantilla`_ (:gh:`43`)
 - Changed the meaning of the argument `channel_wise` in :meth:`~pyprep.NoisyChannels.find_bad_by_ransac` to mean 'perform RANSAC across chunks of channels instead of window-wise', from its original meaning of 'perform channel-wise RANSAC one channel at a time', by `Austin Hurst`_ (:gh:`66`)
+- The arguments `fraction_bad` and `fraction_good` were renamed to `frac_bad` and `sample_prop`, respectively, for :meth:`~pyprep.NoisyChannels.find_bad_by_ransac` and :func:`~pyprep.ransac.find_bad_by_ransac`, by `Austin Hurst`_ (:gh:`88`)
 
 
 .. _changes_0_3_1:

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -1,4 +1,6 @@
 """finds bad channels."""
+from copy import copy
+
 import mne
 import numpy as np
 from mne.utils import check_random_state
@@ -555,6 +557,7 @@ class NoisyChannels:
         exclude_from_ransac = (
             self.bad_by_correlation + self.bad_by_deviation + self.bad_by_dropout
         )
+        rng = copy(self.random_state) if self.matlab_strict else self.random_state
         self.bad_by_ransac, ch_correlations_usable = find_bad_by_ransac(
             self.EEGFiltered,
             self.sample_rate,
@@ -568,7 +571,7 @@ class NoisyChannels:
             corr_window_secs,
             channel_wise,
             max_chunk_size,
-            self.random_state,
+            rng,
             self.matlab_strict,
         )
 

--- a/pyprep/utils.py
+++ b/pyprep/utils.py
@@ -245,7 +245,7 @@ def _get_random_subset(x, size, rand_state):
     size : int
         The number of items to sample. Must be less than the number of input
         items.
-    rand_state : np.random.RandState
+    rand_state : np.random.RandomState
         A random state object to use for random number generation.
 
     Returns

--- a/tests/test_find_noisy_channels.py
+++ b/tests/test_find_noisy_channels.py
@@ -245,6 +245,13 @@ def test_find_bad_by_ransac(raw_tmp):
     # Make sure strict and non-strict matrices differ
     assert not np.allclose(corr["by_window"], corr["by_window_strict"])
 
+    # Ensure that RANSAC doesn't change random state if in MATLAB-strict mode
+    rng = RandomState(RANSAC_RNG)
+    init_state = rng.get_state()[2]
+    nd = NoisyChannels(raw_tmp, do_detrend=False, random_state=rng, matlab_strict=True)
+    nd.find_bad_by_ransac()
+    assert rng.get_state()[2] == init_state
+
 
 def test_find_bad_by_ransac_err(raw_tmp):
     """Test error handling in the `find_bad_by_ransac` method."""


### PR DESCRIPTION
<!--Thanks for contributing-->
<!--If this is your first time, please make sure to read the contributing guideline-->
<!--https://github.com/sappelhoff/pyprep/blob/master/.github/CONTRIBUTING.md-->

# PR Description

Closes #74 (at least as far as MATLAB equivalence is concerned). This PR modifies `NoisyChannels` to always use a copy of the random state object during RANSAC when `matlab_strict` is True. This results in the random state being identical for each run of `NoisyChannels.find_bad_by_ransac`, matching MATLAB PREP.

Also I realize I forgot to update the `whats_new.rst` for the last PR, so I did that here as well!

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [x] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [whats_new.rst][whats-new-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[whats-new-file]: https://github.com/sappelhoff/pyprep/blob/master/docs/whats_new.rst
