### PR TITLE
Make noisy channel exclusion during Reference compatible with MATLAB PREP

### DIFF
--- a/docs/matlab_differences.rst
+++ b/docs/matlab_differences.rst
@@ -177,7 +177,7 @@ process is performed using the following logic:
 
 5) Steps 2 through 4 are repeated until either two iterations have passed and
    no new noisy channels have been detected since the previous iteration, or
-   the maximum number of reference iterations has been exceeded (default: 5).
+   the maximum number of reference iterations has been exceeded (default: 4).
 
 
 Exclusion of dropout channels

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -41,12 +41,15 @@ Changelog
 - Changed RANSAC so that "bad by high-frequency noise" channels are retained when making channel predictions (provided they aren't flagged as bad by any other metric), matching MATLAB PREP behaviour, by `Austin Hurst`_ (:gh:`64`)
 - Added a new flag ``matlab_strict`` to :class:`~pyprep.PrepPipeline`, :class:`~pyprep.Reference`, :class:`~pyprep.NoisyChannels`, and :func:`~pyprep.ransac.find_bad_by_ransac` for optionally matching MATLAB PREP's internal math as closely as possible, overriding areas where PyPREP attempts to improve on the original, by `Austin Hurst`_ (:gh:`70`)
 - Added a ``matlab_strict`` method for high-pass trend removal, exactly matching MATLAB PREP's values if ``matlab_strict`` is enabled, by `Austin Hurst`_ (:gh:`71`)
-- Added a window-wise implementaion of RANSAC and made it the default method, reducing the typical RAM demands of robust re-referencing considerably, by `Austin Hurst`_ (:gh:`66`)
+- Added a window-wise implementation of RANSAC and made it the default method, reducing the typical RAM demands of robust re-referencing considerably, by `Austin Hurst`_ (:gh:`66`)
 - Added `max_chunk_size` parameter for specifying the maximum chunk size to use for channel-wise RANSAC, allowing more control over PyPREP RAM usage, by `Austin Hurst`_ (:gh:`66`)
 - Changed :class:`~pyprep.Reference` to exclude "bad-by-SNR" channels from initial average referencing, matching MATLAB PREP behaviour, by `Austin Hurst`_ (:gh:`78`)
 - Changed :class:`~pyprep.Reference` to only flag "unusable" channels (bad by flat, NaNs, or low SNR) from the first pass of noisy detection for permanent exclusion from the reference signal, matching MATLAB PREP behaviour, by `Austin Hurst`_ (:gh:`78`)
 - Added a framework for automated testing of PyPREP's components against their MATLAB PREP counterparts (using ``.mat`` and ``.set`` files generated with the `matprep_artifacts`_ script), helping verify that the two PREP implementations are numerically equivalent when `matlab_strict` is ``True``, by `Austin Hurst`_ (:gh:`79`)
 - Changed :class:`~pyprep.NoisyChannels` to reuse the same random state for each run of RANSAC when ``matlab_strict`` is ``True``, matching MATLAB PREP behaviour, by `Austin Hurst`_ (:gh:`89`)
+- Added a new argument `as_dict` for :meth:`~pyprep.NoisyChannels.get_bads`, allowing easier retrieval of flagged noisy channels by category, by `Austin Hurst`_ (:gh:`93`)
+- Added a new argument `max_iterations` for :meth:`~pyprep.Reference.perform_reference` and :meth:`~pyprep.Reference.robust_reference`, allowing the maximum number of referencing iterations to be user-configurable, by `Austin Hurst`_ (:gh:`93`)
+- Changed :meth:`~pyprep.Reference.robust_reference` to ignore bad-by-dropout channels during referencing if ``matlab_strict`` is ``True``, matching MATLAB PREP behaviour, by `Austin Hurst`_ (:gh:`93`)
 
 .. _matprep_artifacts: https://github.com/a-hurst/matprep_artifacts
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -50,6 +50,7 @@ Changelog
 - Added a new argument `as_dict` for :meth:`~pyprep.NoisyChannels.get_bads`, allowing easier retrieval of flagged noisy channels by category, by `Austin Hurst`_ (:gh:`93`)
 - Added a new argument `max_iterations` for :meth:`~pyprep.Reference.perform_reference` and :meth:`~pyprep.Reference.robust_reference`, allowing the maximum number of referencing iterations to be user-configurable, by `Austin Hurst`_ (:gh:`93`)
 - Changed :meth:`~pyprep.Reference.robust_reference` to ignore bad-by-dropout channels during referencing if ``matlab_strict`` is ``True``, matching MATLAB PREP behaviour, by `Austin Hurst`_ (:gh:`93`)
+- Changed :meth:`~pyprep.Reference.robust_reference` to allow initial bad-by-SNR channels to be used for rereferencing interpolation if no longer bad following initial average reference, matching MATLAB PREP behaviour, by `Austin Hurst`_ (:gh:`93`)
 
 .. _matprep_artifacts: https://github.com/a-hurst/matprep_artifacts
 

--- a/pyprep/prep_pipeline.py
+++ b/pyprep/prep_pipeline.py
@@ -33,6 +33,9 @@ class PrepPipeline:
               For example, for 60Hz you may specify
               ``np.arange(60, sfreq / 2, 60)``. Specify an empty list to
               skip the line noise removal step.
+        - max_iterations : int, optional
+            - The maximum number of iterations of noisy channel removal to
+              perform during robust referencing. Defaults to ``4``.
     montage : mne.channels.DigMontage
         Digital montage of EEG data.
     ransac : bool, optional
@@ -150,6 +153,8 @@ class PrepPipeline:
             self.prep_params["ref_chs"] = self.ch_names_eeg
         if self.prep_params["reref_chs"] == "eeg":
             self.prep_params["reref_chs"] = self.ch_names_eeg
+        if "max_iterations" not in prep_params.keys():
+            self.prep_params["max_iterations"] = 4
         self.sfreq = self.raw_eeg.info["sfreq"]
         self.ransac_settings = {
             "ransac": ransac,
@@ -215,7 +220,7 @@ class PrepPipeline:
             matlab_strict=self.matlab_strict,
             **self.ransac_settings,
         )
-        reference.perform_reference()
+        reference.perform_reference(self.prep_params["max_iterations"])
         self.raw_eeg = reference.raw
         self.noisy_channels_original = reference.noisy_channels_original
         self.noisy_channels_before_interpolation = (

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -241,10 +241,10 @@ class Reference:
             "bad_by_deviation": [],
             "bad_by_hf_noise": [],
             "bad_by_correlation": [],
-            "bad_by_SNR": noisy_detector.bad_by_SNR,
+            "bad_by_SNR": [],
             "bad_by_dropout": [],
             "bad_by_ransac": [],
-            "bad_all": self.unusable_channels,
+            "bad_all": _union(noisy_detector.bad_by_nan, noisy_detector.bad_by_flat),
         }
 
         # Get initial estimate of the reference by the specified method

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -214,6 +214,7 @@ class Reference:
             "bad_by_SNR": [],
             "bad_by_dropout": [],
             "bad_by_ransac": [],
+            "bad_all": [],
         }
 
         # Get initial estimate of the reference by the specified method

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -134,17 +134,7 @@ class Reference:
         # Record Noisy channels and EEG before interpolation
         self.bad_before_interpolation = noisy_detector.get_bads(verbose=True)
         self.EEG_before_interpolation = self.EEG.copy()
-        self.noisy_channels_before_interpolation = {
-            "bad_by_nan": noisy_detector.bad_by_nan,
-            "bad_by_flat": noisy_detector.bad_by_flat,
-            "bad_by_deviation": noisy_detector.bad_by_deviation,
-            "bad_by_hf_noise": noisy_detector.bad_by_hf_noise,
-            "bad_by_correlation": noisy_detector.bad_by_correlation,
-            "bad_by_SNR": noisy_detector.bad_by_SNR,
-            "bad_by_dropout": noisy_detector.bad_by_dropout,
-            "bad_by_ransac": noisy_detector.bad_by_ransac,
-            "bad_all": noisy_detector.get_bads(),
-        }
+        self.noisy_channels_before_interpolation = noisy_detector.get_bads(as_dict=True)
         self._extra_info["interpolated"] = noisy_detector._extra_info
 
         bad_channels = _union(self.bad_before_interpolation, self.unusable_channels)
@@ -170,17 +160,7 @@ class Reference:
         noisy_detector.find_all_bads(**self.ransac_settings)
         self.still_noisy_channels = noisy_detector.get_bads()
         self.raw.info["bads"] = self.still_noisy_channels
-        self.noisy_channels_after_interpolation = {
-            "bad_by_nan": noisy_detector.bad_by_nan,
-            "bad_by_flat": noisy_detector.bad_by_flat,
-            "bad_by_deviation": noisy_detector.bad_by_deviation,
-            "bad_by_hf_noise": noisy_detector.bad_by_hf_noise,
-            "bad_by_correlation": noisy_detector.bad_by_correlation,
-            "bad_by_SNR": noisy_detector.bad_by_SNR,
-            "bad_by_dropout": noisy_detector.bad_by_dropout,
-            "bad_by_ransac": noisy_detector.bad_by_ransac,
-            "bad_all": noisy_detector.get_bads(),
-        }
+        self.noisy_channels_after_interpolation = noisy_detector.get_bads(as_dict=True)
         self._extra_info["remaining_bad"] = noisy_detector._extra_info
 
         return self
@@ -213,17 +193,7 @@ class Reference:
             matlab_strict=self.matlab_strict,
         )
         noisy_detector.find_all_bads(**self.ransac_settings)
-        self.noisy_channels_original = {
-            "bad_by_nan": noisy_detector.bad_by_nan,
-            "bad_by_flat": noisy_detector.bad_by_flat,
-            "bad_by_deviation": noisy_detector.bad_by_deviation,
-            "bad_by_hf_noise": noisy_detector.bad_by_hf_noise,
-            "bad_by_correlation": noisy_detector.bad_by_correlation,
-            "bad_by_SNR": noisy_detector.bad_by_SNR,
-            "bad_by_dropout": noisy_detector.bad_by_dropout,
-            "bad_by_ransac": noisy_detector.bad_by_ransac,
-            "bad_all": noisy_detector.get_bads(),
-        }
+        self.noisy_channels_original = noisy_detector.get_bads(as_dict=True)
         self._extra_info["initial_bad"] = noisy_detector._extra_info
         logger.info("Bad channels: {}".format(self.noisy_channels_original))
 

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -279,6 +279,8 @@ class Reference:
                 and (len(bad_chans) == 0 or bad_chans == previous_bads)
                 or iterations > max_iterations
             ):
+                logger.info("Robust reference done")
+                self.noisy_channels = noisy
                 break
             previous_bads = bad_chans.copy()
 
@@ -305,8 +307,6 @@ class Reference:
             iterations = iterations + 1
             logger.info("Iterations: {}".format(iterations))
 
-        logger.info("Robust reference done")
-        self.noisy_channels = noisy
         return self.noisy_channels, self.reference_signal
 
     @staticmethod

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -255,8 +255,8 @@ class Reference:
             # Update set of all noisy channels detected so far with any new ones
             bad_chans = set()
             for bad_type in noisy_new.keys():
+                noisy[bad_type] = _union(noisy[bad_type], noisy_new[bad_type])
                 if bad_type not in ignore:
-                    noisy[bad_type] = _union(noisy[bad_type], noisy_new[bad_type])
                     bad_chans.update(noisy[bad_type])
             noisy["bad_all"] = list(bad_chans)
             logger.info("Bad channels: {}".format(noisy))

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -44,8 +44,8 @@ def test_clean_input(raw_clean):
         reference.robust_reference()
 
     assert len(reference.unusable_channels) == 0
-    assert len(reference.noisy_channels_original['bad_all']) == 0
-    assert len(reference.noisy_channels['bad_all']) == 0
+    assert len(reference.noisy_channels_original["bad_all"]) == 0
+    assert len(reference.noisy_channels["bad_all"]) == 0
 
 
 @pytest.mark.usefixtures("raw", "montage")

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -1,5 +1,4 @@
 """Test Robust Reference."""
-import random
 from unittest import mock
 
 import mne

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -48,31 +48,22 @@ def test_clean_input(raw_clean):
     assert len(reference.noisy_channels["bad_all"]) == 0
 
 
-@pytest.mark.usefixtures("raw", "montage")
-def test_all_bad_input(raw, montage):
+@pytest.mark.usefixtures("raw_clean")
+def test_all_bad_input(raw_clean):
     """Test robust reference when all reference channels are bad."""
-    ch_names = raw.info["ch_names"]
+    ch_names = raw_clean.info["ch_names"]
+    params = {"ref_chs": ch_names, "reref_chs": ch_names}
 
-    raw_tmp = raw.copy()
-    raw_tmp.set_montage(montage)
-    m, n = raw_tmp.get_data().shape
+    # Define a mock function to make all channels bad by deviation
+    def _bad_by_dev(self):
+        self.bad_by_deviation = self.ch_names_original.tolist()
 
-    # Randomly set some channels as bad
-    [nan_chn_idx, flat_chn_idx] = random.sample(set(np.arange(0, m)), 2)
-
-    # Insert a nan value for a random channel
-    # nan_chn_lab = raw_tmp.ch_names[nan_chn_idx]
-    raw_tmp._data[nan_chn_idx, n - 1] = np.nan
-
-    # Insert one random flat channel
-    # flat_chn_lab = raw_tmp.ch_names[flat_chn_idx]
-    raw_tmp._data[flat_chn_idx, :] = np.ones_like(raw_tmp._data[1, :]) * 1e-6
-
-    reference_channels = [ch_names[nan_chn_idx], ch_names[flat_chn_idx]]
-    params = {"ref_chs": reference_channels, "reref_chs": reference_channels}
-    reference = Reference(raw_tmp, params, ransac=False)
-    with pytest.raises(ValueError):
-        reference.robust_reference()
+    # Here we monkey-patch Reference to make all channels bad by deviation, allowing
+    # us to test the 'too-few-good-channels' exception
+    with mock.patch("pyprep.NoisyChannels.find_bad_by_deviation", new=_bad_by_dev):
+        reference = Reference(raw_clean, params, ransac=False)
+        with pytest.raises(ValueError):
+            reference.robust_reference()
 
 
 def test_remove_reference():


### PR DESCRIPTION
<!--Thanks for contributing-->
<!--If this is your first time, please make sure to read the contributing guideline-->
<!--https://github.com/sappelhoff/pyprep/blob/master/.github/CONTRIBUTING.md-->

# PR Description

Closes #91. This PR does three main things:

- Changes `Reference.robust_reference` to stop permanently excluding channels that are flagged as bad-by-SNR prior to initial re-referencing.
- Changes `Reference.robust_reference` to exclude bad-by-dropout channels from the full set of bad channels when`matlab_strict` is `True`, matching MatPREP's (likely accidental) behaviour.
- Adds an `as_dict` argument to `NoisyChannels.get_bads` that returns bad channels by type as a dictionary in order to facilitate the above changes. In addition to being generally useful, it also saves a lot of dict construction in `reference.py`.

I still need to update the `whats_new.rst` and `matlab_differences.rst` here, but I figured given the time-zone difference that it would be better to get the code up for review before I went to bed. Thanks in advance for checking this over!

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [x] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [whats_new.rst][whats-new-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[whats-new-file]: https://github.com/sappelhoff/pyprep/blob/master/docs/whats_new.rst
