### PR TITLE
Always keep EEG data in Volts instead of converting to mV

### DIFF
--- a/pyprep/prep_pipeline.py
+++ b/pyprep/prep_pipeline.py
@@ -147,7 +147,7 @@ class PrepPipeline:
         # raw_non_eeg may not be compatible with the montage
         # so it is not set for that object
 
-        self.EEG_raw = self.raw_eeg.get_data() * 1e6
+        self.EEG_raw = self.raw_eeg.get_data()
         self.prep_params = prep_params
         if self.prep_params["ref_chs"] == "eeg":
             self.prep_params["ref_chs"] = self.ch_names_eeg
@@ -210,7 +210,7 @@ class PrepPipeline:
 
             # Add Trend back
             self.EEG = self.EEG_raw - self.EEG_new + self.EEG_clean
-            self.raw_eeg._data = self.EEG * 1e-6
+            self.raw_eeg._data = self.EEG
 
         # Step 3: Referencing
         reference = Reference(

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -80,7 +80,7 @@ class Reference:
         self.ch_names = self.raw.ch_names
         self.raw.pick_types(eeg=True, eog=False, meg=False)
         self.ch_names_eeg = self.raw.ch_names
-        self.EEG = self.raw.get_data() * 1e6
+        self.EEG = self.raw.get_data()
         self.reference_channels = params["ref_chs"]
         self.rereferenced_channels = params["reref_chs"]
         self.sfreq = self.raw.info["sfreq"]
@@ -123,7 +123,7 @@ class Reference:
         else:
             dummy.interpolate_bads()
         self.reference_signal = (
-            np.nanmean(dummy.get_data(picks=self.reference_channels), axis=0) * 1e6
+            np.nanmean(dummy.get_data(picks=self.reference_channels), axis=0)
         )
         del dummy
         rereferenced_index = [
@@ -134,7 +134,7 @@ class Reference:
         )
 
         # Phase 2: Find the bad channels and interpolate
-        self.raw._data = self.EEG * 1e-6
+        self.raw._data = self.EEG
         noisy_detector = NoisyChannels(
             self.raw, random_state=self.random_state, matlab_strict=self.matlab_strict
         )
@@ -153,16 +153,16 @@ class Reference:
         else:
             self.raw.interpolate_bads()
         reference_correct = (
-            np.nanmean(self.raw.get_data(picks=self.reference_channels), axis=0) * 1e6
+            np.nanmean(self.raw.get_data(picks=self.reference_channels), axis=0)
         )
-        self.EEG = self.raw.get_data() * 1e6
+        self.EEG = self.raw.get_data()
         self.EEG = self.remove_reference(
             self.EEG, reference_correct, rereferenced_index
         )
         # reference signal after interpolation
         self.reference_signal_new = self.reference_signal + reference_correct
         # MNE Raw object after interpolation
-        self.raw._data = self.EEG * 1e-6
+        self.raw._data = self.EEG
 
         # Still noisy channels after interpolation
         self.interpolated_channels = bad_channels

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -236,9 +236,9 @@ class Reference:
         }
 
         # Get initial estimate of the reference by the specified method
-        signal = raw.get_data() * 1e6
+        signal = raw.get_data()
         self.reference_signal = (
-            np.nanmedian(raw.get_data(picks=reference_channels), axis=0) * 1e6
+            np.nanmedian(raw.get_data(picks=reference_channels), axis=0)
         )
         reference_index = [self.ch_names_eeg.index(ch) for ch in reference_channels]
         signal_tmp = self.remove_reference(
@@ -251,7 +251,7 @@ class Reference:
         previous_bads = set()
 
         while True:
-            raw_tmp._data = signal_tmp * 1e-6
+            raw_tmp._data = signal_tmp
             noisy_detector = NoisyChannels(
                 raw_tmp,
                 do_detrend=False,
@@ -297,7 +297,7 @@ class Reference:
                 )
 
             if len(bad_chans) > 0:
-                raw_tmp._data = signal * 1e-6
+                raw_tmp._data = signal.copy()
                 raw_tmp.info["bads"] = list(bad_chans)
                 if self.matlab_strict:
                     _eeglab_interpolate_bads(raw_tmp)
@@ -305,7 +305,7 @@ class Reference:
                     raw_tmp.interpolate_bads()
 
             self.reference_signal = (
-                np.nanmean(raw_tmp.get_data(picks=reference_channels), axis=0) * 1e6
+                np.nanmean(raw_tmp.get_data(picks=reference_channels), axis=0)
             )
 
             signal_tmp = self.remove_reference(

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -303,9 +303,7 @@ class Reference:
                     _eeglab_interpolate_bads(raw_tmp)
                 else:
                     raw_tmp.interpolate_bads()
-                signal_tmp = raw_tmp.get_data() * 1e6
-            else:
-                signal_tmp = signal
+
             self.reference_signal = (
                 np.nanmean(raw_tmp.get_data(picks=reference_channels), axis=0) * 1e6
             )

--- a/tests/test_matprep_compare.py
+++ b/tests/test_matprep_compare.py
@@ -378,7 +378,7 @@ class TestCompareRobustReference(object):
     def test_reference_signal(self, pyprep_reference, matprep_info):
         """Compare the final reference signal between PyPREP and MatPREP."""
         TOL = 1e-4  # NOTE: Some diffs > 1e-5, maybe rounding error?
-        pyprep_ref = pyprep_reference.reference_signal_new
+        pyprep_ref = pyprep_reference.reference_signal_new * 1e6
         assert np.allclose(pyprep_ref, matprep_info["ref_signal"], atol=TOL)
 
     def test_full_signal(self, pyprep_reference, matprep_reference):


### PR DESCRIPTION
<!--Thanks for contributing-->
<!--If this is your first time, please make sure to read the contributing guideline-->
<!--https://github.com/sappelhoff/pyprep/blob/master/.github/CONTRIBUTING.md-->

# PR Description

This PR removes a bunch of unnecessary conversions back and forth between Volts and mV, likewise changing the units for a few user-facing EEG attributes (e.g. `self.EEG_before_interpolation`) in `PrepPipeline` from the EEGLAB standard of mV to the MNE standard of volts.

This should make the API less confusing for people used to working in the MNE world, avoid a bunch of unnecessary large matrix multiplication, and makes some other proposed API changes in #99 easier to implement.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [ ] the PR has been reviewed and all comments are resolved
- [ ] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [whats_new.rst][whats-new-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[whats-new-file]: https://github.com/sappelhoff/pyprep/blob/master/docs/whats_new.rst
