### PR TITLE
Improve documentation for PyPREP/MatPREP highpass differences

### DIFF
--- a/docs/matlab_differences.rst
+++ b/docs/matlab_differences.rst
@@ -33,9 +33,9 @@ In MATLAB PREP, the default method of trend removal is to use EEGLAB's
 data. MNE's :func:`mne.filter.filter_data` offers similar functionality, but
 with two key differences:
 
-1) MNE's method of FIR filter design is slightly different, resulting in
-   slightly higher FIR filter orders in EEGLAB than in MNE for the same input
-   values.
+1) MNE's method of FIR filter design has minor differences, resulting in
+   slightly lower FIR filter orders than EEGLAB for the same input
+   values (e.g. 845 instead of EEGLAB's 847).
 2) EEGLAB's ``pop_eegfiltnew`` only applies the filter to the signal forwards,
    resulting in minor phase shift in the filtered signal. By contrast, MNE
    defaults to applying the filter both forwards and backwards, eliminating any

--- a/docs/matlab_differences.rst
+++ b/docs/matlab_differences.rst
@@ -31,13 +31,23 @@ influence from trends in the signal.
 In MATLAB PREP, the default method of trend removal is to use EEGLAB's
 ``pop_eegfiltnew``, which creates and applies an FIR high-pass filter to the
 data. MNE's :func:`mne.filter.filter_data` offers similar functionality, but
-uses slightly different filter creation math and a different filtering
-algorithm such that its results and subsequent :class:`~pyprep.NoisyChannels`
-values also differ slightly (on the order of ~0.002) for RANSAC correlations.
+with two key differences:
 
-Because the practical differences are small and MNE's filtering is fast and
-well-tested, PyPREP defaults to using :func:`mne.filter.filter_data` for
-high-pass trend removal. However, for exact numerical compatibility, PyPREP
+1) MNE's method of FIR filter design is slightly different, resulting in
+   slightly higher FIR filter orders in EEGLAB than in MNE for the same input
+   values.
+2) EEGLAB's ``pop_eegfiltnew`` only applies the filter to the signal forwards,
+   resulting in minor phase shift in the filtered signal. By contrast, MNE
+   defaults to applying the filter both forwards and backwards, eliminating any
+   phase shift from the filtering process.
+
+As a result of these differences, :class:`~pyprep.NoisyChannels` values also
+differ slightly (on the order of ~0.002) for RANSAC correlations between the
+filtering methods.
+
+Because MNE's filtering code is faster and technically preferable (due to
+the lack of phase shift) PyPREP defaults to using :func:`mne.filter.filter_data`
+for high-pass trend removal. However, for exact numeric equivalence, PyPREP
 has a basic re-implementation of EEGLAB's ``pop_eegfiltnew`` in Python that
 produces identical results to MATLAB PREP's ``removeTrend`` when the
 ``matlab_strict`` parameter is set to ``True``.

--- a/examples/run_full_prep.py
+++ b/examples/run_full_prep.py
@@ -131,7 +131,7 @@ EEG_raw_matlab = EEG_raw_matlab["save_data"]
 EEG_raw_diff = EEG_raw - EEG_raw_matlab
 EEG_raw_mse = (EEG_raw_diff / EEG_raw_max ** 2).mean(axis=None)
 
-fig, axs = plt.subplots(5, 3, "all", figsize=(16, 12))
+fig, axs = plt.subplots(5, 3, sharex="all", figsize=(16, 12))
 plt.setp(fig, facecolor=[1, 1, 1])
 fig.suptitle("Python versus Matlab PREP results", fontsize=16)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ flake8
 flake8-docstrings
 isort
 matplotlib
+mne[data]
 numpydoc
 pillow
 pre-commit

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,8 @@ flake8
 flake8-docstrings
 isort
 matplotlib
-mne[data]
+tdqm
+pooch
 numpydoc
 pillow
 pre-commit


### PR DESCRIPTION
<!--Thanks for contributing-->
<!--If this is your first time, please make sure to read the contributing guideline-->
<!--https://github.com/sappelhoff/pyprep/blob/master/.github/CONTRIBUTING.md-->

# PR Description

Closes #107. This PR updates the docs to contain a better explanation of the differences between PyPREP's and MatPREP's trend removal filters (and why the MNE method is technically preferable).

Wasn't sure if this warranted an addition in the `whats_new.rst`, but if it does I can definitely add a line!

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [x] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [whats_new.rst][whats-new-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[whats-new-file]: https://github.com/sappelhoff/pyprep/blob/master/docs/whats_new.rst
