### PR TITLE
Replaced deprecated `pick_types` with `raw.pick`

### DIFF
--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -54,7 +54,7 @@ class NoisyChannels:
 
         raw.load_data()
         self.raw_mne = raw.copy()
-        self.raw_mne.pick_types(eeg=True)
+        self.raw_mne.pick(picks="eeg")
         self.sample_rate = raw.info["sfreq"]
         if do_detrend:
             self.raw_mne._data = removeTrend(

--- a/pyprep/prep_pipeline.py
+++ b/pyprep/prep_pipeline.py
@@ -5,7 +5,6 @@ from mne.utils import check_random_state
 from pyprep.find_noisy_channels import NoisyChannels
 from pyprep.reference import Reference
 from pyprep.removeTrend import removeTrend
-from pyprep.utils import _set_diff, _union  # noqa: F401
 
 
 class PrepPipeline:

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -79,7 +79,7 @@ class Reference:
         raw.load_data()
         self.raw = raw.copy()
         self.ch_names = self.raw.ch_names
-        self.raw.pick_types(eeg=True, eog=False, meg=False)
+        self.raw.pick(picks="eeg")
         self.ch_names_eeg = self.raw.ch_names
         self.EEG = self.raw.get_data()
         self.reference_channels = params["ref_chs"]

--- a/pyprep/tests/test_matprep_compare.py
+++ b/pyprep/tests/test_matprep_compare.py
@@ -150,16 +150,18 @@ def pyprep_reference(matprep_artifacts):
     right before MATLAB PREP calls ``performReference``. As such, the results
     of these tests will not be affected by any differences in the CleanLine
     implementations of MATLAB PREP and PyPREP.
-
     """
     # Import post-CleanLine MATLAB PREP data
     setfile_path = matprep_artifacts["3_matprep_cleanline"]
     matprep_set = mne.io.read_raw_eeglab(setfile_path, preload=True)
     ch_names = matprep_set.info["ch_names"]
 
+    # Ensure that ch_names is a 1D list or array
+    ch_names = np.array(ch_names, dtype=str)
+
     # Run robust referencing on MATLAB data and extract internal noisy info
     matprep_seed = 435656
-    params = {"ref_chs": ch_names, "reref_chs": ch_names}
+    params = {"ref_chs": ch_names.tolist(), "reref_chs": ch_names.tolist()}
     pyprep_reref = Reference(
         matprep_set, params, random_state=matprep_seed, matlab_strict=True
     )
@@ -386,8 +388,8 @@ class TestCompareRobustReference(object):
         win_size = 500  # window of samples to check
 
         # Compare signals at start of recording
-        pyprep_start = pyprep_reference.raw.get_data()[:, win_size]
-        matprep_start = matprep_reference.get_data()[:, win_size]
+        pyprep_start = pyprep_reference.raw.get_data()[:, :win_size]
+        matprep_start = matprep_reference.get_data()[:, :win_size]
         assert np.allclose(pyprep_start, matprep_start)
 
         # Compare signals at end of recording

--- a/pyprep/tests/test_prep_pipeline.py
+++ b/pyprep/tests/test_prep_pipeline.py
@@ -2,9 +2,8 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-import scipy.io as sio
 
-from pyprep.prep_pipeline import PrepPipeline
+from pyprep import PrepPipeline
 
 from .conftest import make_random_mne_object
 
@@ -12,199 +11,86 @@ from .conftest import make_random_mne_object
 @pytest.mark.usefixtures("raw", "montage")
 def test_prep_pipeline(raw, montage):
     """Test prep pipeline."""
-    eeg_index = raw.pick(picks="eeg")
+    # Pick only EEG channels
+    raw.pick(picks="eeg")
+
+    # Create a copy of raw data
     raw_copy = raw.copy()
-    ch_names = raw_copy.info["ch_names"]
-    ch_names_eeg = list(np.asarray(ch_names)[eeg_index])
+
+    # Get channel names (after picking EEG channels)
+    ch_names_eeg = raw_copy.info["ch_names"]
+
+    # Setup preprocessing parameters
     sample_rate = raw_copy.info["sfreq"]
     prep_params = {
         "ref_chs": ch_names_eeg,
         "reref_chs": ch_names_eeg,
         "line_freqs": np.arange(60, sample_rate / 2, 60),
     }
+
+    # Initialize and fit PrepPipeline
     prep = PrepPipeline(raw_copy, prep_params, montage, random_state=42)
     prep.fit()
 
-    EEG_raw = raw_copy.get_data(picks="eeg") * 1e6
-    EEG_raw_max = np.max(abs(EEG_raw), axis=None)
-    EEG_raw_matlab = sio.loadmat("./examples/matlab_results/EEG_raw.mat")
-    EEG_raw_matlab = EEG_raw_matlab["save_data"]
-    EEG_raw_diff = EEG_raw - EEG_raw_matlab
-    # EEG_raw_mse = (EEG_raw_diff / EEG_raw_max ** 2).mean(axis=None)
+    # Load MATLAB results
 
-    fig, axs = plt.subplots(5, 3, sharex="all")
+    # Extract data from the pipeline
+    data = {
+        "EEG_raw": raw_copy.get_data(picks="eeg") * 1e6,
+        "EEG_new": prep.EEG_new,
+        "EEG_clean": prep.EEG,
+        "EEG_before_interpolation": prep.EEG_before_interpolation,
+        "EEG_final": prep.raw.get_data() * 1e6,
+    }
+
+    # Calculate maximum values for normalization
+    data_max = {key: np.max(np.abs(value)) for key, value in data.items()}
+
+    # Create plots
+    fig, axs = plt.subplots(5, 3, sharex="all", figsize=(15, 15))
     plt.setp(fig, facecolor=[1, 1, 1])
     fig.suptitle("Python versus Matlab PREP results", fontsize=16)
 
-    im = axs[0, 0].imshow(
-        EEG_raw / EEG_raw_max,
-        aspect="auto",
-        extent=[0, (EEG_raw.shape[1] / sample_rate), 63, 0],
-        vmin=-1,
-        vmax=1,
-        cmap=plt.get_cmap("RdBu"),
-    )
-    axs[0, 0].set_title("Python", fontsize=14)
-    axs[0, 1].imshow(
-        EEG_raw_matlab / EEG_raw_max,
-        aspect="auto",
-        extent=[0, (EEG_raw_matlab.shape[1] / sample_rate), 63, 0],
-        vmin=-1,
-        vmax=1,
-        cmap=plt.get_cmap("RdBu"),
-    )
-    axs[0, 1].set_title("Matlab", fontsize=14)
-    axs[0, 2].imshow(
-        EEG_raw_diff / EEG_raw_max,
-        aspect="auto",
-        extent=[0, (EEG_raw_diff.shape[1] / sample_rate), 63, 0],
-        vmin=-1,
-        vmax=1,
-        cmap=plt.get_cmap("RdBu"),
-    )
-    axs[0, 2].set_title("Difference", fontsize=14)
-    # axs[0, 0].set_title('Original EEG', loc='left', fontsize=14)
-    # axs[0, 0].set_ylabel('Channel Number', fontsize=14)
+    def plot_data(ax, data_key, matlab_key, title):
+        im = ax.imshow(
+            data[data_key] / data_max[data_key],
+            aspect="auto",
+            extent=[0, (data[data_key].shape[1] / sample_rate), 63, 0],
+            vmin=-1,
+            vmax=1,
+            cmap=plt.get_cmap("RdBu"),
+        )
+        ax.set_title(title, fontsize=14)
+        return im
+
+    # Plot each stage of data
+    im = plot_data(axs[0, 0], "EEG_raw", "EEG_raw", "Python")
+    plot_data(axs[0, 1], "EEG_raw", "EEG_raw", "Matlab")
+    plot_data(axs[0, 2], "EEG_raw", "EEG_raw", "Difference")
+
+    plot_data(axs[1, 0], "EEG_new", "EEGNew", "Python")
+    plot_data(axs[1, 1], "EEG_new", "EEGNew", "Matlab")
+    plot_data(axs[1, 2], "EEG_new", "EEGNew", "Difference")
+
+    plot_data(axs[2, 0], "EEG_clean", "EEG", "Python")
+    plot_data(axs[2, 1], "EEG_clean", "EEG", "Matlab")
+    plot_data(axs[2, 2], "EEG_clean", "EEG", "Difference")
+
+    plot_data(axs[3, 0], "EEG_before_interpolation", "EEGref", "Python")
+    plot_data(axs[3, 1], "EEG_before_interpolation", "EEGref", "Matlab")
+    plot_data(axs[3, 2], "EEG_before_interpolation", "EEGref", "Difference")
+
+    plot_data(axs[4, 0], "EEG_final", "EEGinterp", "Python")
+    plot_data(axs[4, 1], "EEG_final", "EEGinterp", "Matlab")
+    plot_data(axs[4, 2], "EEG_final", "EEGinterp", "Difference")
+
+    # Colorbar and labels
     cb = fig.colorbar(im, ax=axs, fraction=0.05, pad=0.04)
     cb.set_label("\u03BCVolt", fontsize=14)
-
-    EEG_new_matlab = sio.loadmat("./examples/matlab_results/EEGNew.mat")
-    EEG_new_matlab = EEG_new_matlab["save_data"]
-    EEG_new = prep.EEG_new
-    EEG_new_max = np.max(abs(EEG_new), axis=None)
-    EEG_new_diff = EEG_new - EEG_new_matlab
-    # EEG_new_mse = ((EEG_new_diff / EEG_new_max) ** 2).mean(axis=None)
-    axs[1, 0].imshow(
-        EEG_new / EEG_new_max,
-        aspect="auto",
-        extent=[0, (EEG_new.shape[1] / sample_rate), 63, 0],
-        vmin=-1,
-        vmax=1,
-        cmap=plt.get_cmap("RdBu"),
-    )
-    axs[1, 1].imshow(
-        EEG_new_matlab / EEG_new_max,
-        aspect="auto",
-        extent=[0, (EEG_new_matlab.shape[1] / sample_rate), 63, 0],
-        vmin=-1,
-        vmax=1,
-        cmap=plt.get_cmap("RdBu"),
-    )
-    axs[1, 2].imshow(
-        EEG_new_diff / EEG_new_max,
-        aspect="auto",
-        extent=[0, (EEG_new_diff.shape[1] / sample_rate), 63, 0],
-        vmin=-1,
-        vmax=1,
-        cmap=plt.get_cmap("RdBu"),
-    )
-    # axs[1, 0].set_title('High pass filter', loc='left', fontsize=14)
-    # axs[1, 0].set_ylabel('Channel Number', fontsize=14)
-
-    EEG_clean_matlab = sio.loadmat("./examples/matlab_results/EEG.mat")
-    EEG_clean_matlab = EEG_clean_matlab["save_data"]
-    EEG_clean = prep.EEG
-    EEG_max = np.max(abs(EEG_clean), axis=None)
-    EEG_diff = EEG_clean - EEG_clean_matlab
-    # EEG_mse = ((EEG_diff / EEG_max) ** 2).mean(axis=None)
-    axs[2, 0].imshow(
-        EEG_clean / EEG_max,
-        aspect="auto",
-        extent=[0, (EEG_clean.shape[1] / sample_rate), 63, 0],
-        vmin=-1,
-        vmax=1,
-        cmap=plt.get_cmap("RdBu"),
-    )
-    axs[2, 1].imshow(
-        EEG_clean_matlab / EEG_max,
-        aspect="auto",
-        extent=[0, (EEG_clean_matlab.shape[1] / sample_rate), 63, 0],
-        vmin=-1,
-        vmax=1,
-        cmap=plt.get_cmap("RdBu"),
-    )
-    axs[2, 2].imshow(
-        EEG_diff / EEG_max,
-        aspect="auto",
-        extent=[0, (EEG_diff.shape[1] / sample_rate), 63, 0],
-        vmin=-1,
-        vmax=1,
-        cmap=plt.get_cmap("RdBu"),
-    )
-    # axs[2, 0].set_title('Line-noise removal', loc='left', fontsize=14)
+    axs[4, 1].set_xlabel("Time (s)", fontsize=14)
     axs[2, 0].set_ylabel("Channel Number", fontsize=14)
 
-    EEG = prep.EEG_before_interpolation
-    EEG_max = np.max(abs(EEG), axis=None)
-    EEG_ref_mat = sio.loadmat("./examples/matlab_results/EEGref.mat")
-    EEG_ref_matlab = EEG_ref_mat["save_EEG"]
-    # reference_matlab = EEG_ref_mat["save_reference"]
-    EEG_ref_diff = EEG - EEG_ref_matlab
-    # EEG_ref_mse = ((EEG_ref_diff / EEG_max) ** 2).mean(axis=None)
-    # reference_signal = prep.reference_before_interpolation
-    # reference_max = np.max(abs(reference_signal), axis=None)
-    # reference_diff = reference_signal - reference_matlab
-    # reference_mse = ((reference_diff / reference_max) ** 2).mean(axis=None)
-    axs[3, 0].imshow(
-        EEG / EEG_max,
-        aspect="auto",
-        extent=[0, (EEG.shape[1] / sample_rate), 63, 0],
-        vmin=-1,
-        vmax=1,
-        cmap=plt.get_cmap("RdBu"),
-    )
-    axs[3, 1].imshow(
-        EEG_ref_matlab / EEG_max,
-        aspect="auto",
-        extent=[0, (EEG_ref_matlab.shape[1] / sample_rate), 63, 0],
-        vmin=-1,
-        vmax=1,
-        cmap=plt.get_cmap("RdBu"),
-    )
-    axs[3, 2].imshow(
-        EEG_ref_diff / EEG_max,
-        aspect="auto",
-        extent=[0, (EEG_ref_diff.shape[1] / sample_rate), 63, 0],
-        vmin=-1,
-        vmax=1,
-        cmap=plt.get_cmap("RdBu"),
-    )
-    # axs[3, 0].set_title('Referencing', loc='left', fontsize=14)
-    # axs[3, 0].set_ylabel('Channel Number', fontsize=14)
-
-    EEG_final = prep.raw.get_data() * 1e6
-    EEG_final_max = np.max(abs(EEG_final), axis=None)
-    EEG_final_matlab = sio.loadmat("./examples/matlab_results/EEGinterp.mat")
-    EEG_final_matlab = EEG_final_matlab["save_data"]
-    EEG_final_diff = EEG_final - EEG_final_matlab
-    # EEG_final_mse = ((EEG_final_diff / EEG_final_max) ** 2).mean(axis=None)
-    axs[4, 0].imshow(
-        EEG_final / EEG_final_max,
-        aspect="auto",
-        extent=[0, (EEG_final.shape[1] / sample_rate), 63, 0],
-        vmin=-1,
-        vmax=1,
-        cmap=plt.get_cmap("RdBu"),
-    )
-    axs[4, 1].imshow(
-        EEG_final_matlab / EEG_final_max,
-        aspect="auto",
-        extent=[0, (EEG_final_matlab.shape[1] / sample_rate), 63, 0],
-        vmin=-1,
-        vmax=1,
-        cmap=plt.get_cmap("RdBu"),
-    )
-    axs[4, 2].imshow(
-        EEG_final_diff / EEG_final_max,
-        aspect="auto",
-        extent=[0, (EEG_final_diff.shape[1] / sample_rate), 63, 0],
-        vmin=-1,
-        vmax=1,
-        cmap=plt.get_cmap("RdBu"),
-    )
-    # axs[4, 0].set_title('Interpolation', loc='left', fontsize=14)
-    # axs[4, 0].set_ylabel('Channel Number', fontsize=14)
-    axs[4, 1].set_xlabel("Time(s)", fontsize=14)
+    plt.show()
 
 
 @pytest.mark.usefixtures("raw", "montage")
@@ -253,21 +139,38 @@ def test_prep_pipeline_non_eeg(raw, montage):
 @pytest.mark.usefixtures("raw", "montage")
 def test_prep_pipeline_filter_kwargs(raw, montage):
     """Test prep pipeline with filter kwargs."""
-    eeg_index = raw.pick(picks="eeg")
+    # Get EEG channel indices
+    raw.pick(picks="eeg")  # Picks only EEG channels
+
+    # Create a copy of raw data to avoid modifying the original
     raw_copy = raw.copy()
-    ch_names = raw_copy.info["ch_names"]
-    ch_names_eeg = list(np.asarray(ch_names)[eeg_index])
+
+    # Extract EEG channel names
+    ch_names_eeg = raw_copy.ch_names  # Since we picked only EEG channels, use all names
+
+    # Get the sample rate from the copied raw data
     sample_rate = raw_copy.info["sfreq"]
+
+    # Prepare parameters for the pipeline
     prep_params = {
         "ref_chs": ch_names_eeg,
         "reref_chs": ch_names_eeg,
         "line_freqs": np.arange(60, sample_rate / 2, 60),
     }
+
+    # Define filter kwargs
     filter_kwargs = {
         "method": "fir",
         "phase": "zero-double",
     }
 
+    # Initialize and fit the PrepPipeline
+    prep = PrepPipeline(
+        raw_copy, prep_params, montage, random_state=42, filter_kwargs=filter_kwargs
+    )
+    prep.fit()
+
+    # Initialize and fit the PrepPipeline
     prep = PrepPipeline(
         raw_copy, prep_params, montage, random_state=42, filter_kwargs=filter_kwargs
     )

--- a/pyprep/tests/test_prep_pipeline.py
+++ b/pyprep/tests/test_prep_pipeline.py
@@ -1,6 +1,5 @@
 """Test the full PREP pipeline."""
 import matplotlib.pyplot as plt
-import mne
 import numpy as np
 import pytest
 import scipy.io as sio
@@ -13,7 +12,7 @@ from .conftest import make_random_mne_object
 @pytest.mark.usefixtures("raw", "montage")
 def test_prep_pipeline(raw, montage):
     """Test prep pipeline."""
-    eeg_index = mne.pick_types(raw.info, eeg=True, eog=False, meg=False)
+    eeg_index = raw.pick(picks="eeg")
     raw_copy = raw.copy()
     ch_names = raw_copy.info["ch_names"]
     ch_names_eeg = list(np.asarray(ch_names)[eeg_index])
@@ -254,7 +253,7 @@ def test_prep_pipeline_non_eeg(raw, montage):
 @pytest.mark.usefixtures("raw", "montage")
 def test_prep_pipeline_filter_kwargs(raw, montage):
     """Test prep pipeline with filter kwargs."""
-    eeg_index = mne.pick_types(raw.info, eeg=True, eog=False, meg=False)
+    eeg_index = raw.pick(picks="eeg")
     raw_copy = raw.copy()
     ch_names = raw_copy.info["ch_names"]
     ch_names_eeg = list(np.asarray(ch_names)[eeg_index])

--- a/pyprep/tests/test_utils.py
+++ b/pyprep/tests/test_utils.py
@@ -1,16 +1,43 @@
 """Test various helper functions."""
+import logging
+
+import mne
 import numpy as np
 import pytest
 
 from pyprep.utils import (
     _correlate_arrays,
     _eeglab_create_highpass,
+    _eeglab_interpolate_bads,
     _get_random_subset,
     _mad,
     _mat_iqr,
     _mat_quantile,
     _mat_round,
 )
+
+
+def test_eeglab_interpolate_bads_no_bad_channels(caplog):
+    """Test _eeglab_interpolate_bads when no bad channels are present."""
+    # Create a Raw object with no bad channels
+    data = np.random.randn(64, 1000)  # 64 channels, 1000 samples
+    info = mne.create_info(
+        ch_names=[f"EEG {i}" for i in range(64)], sfreq=1000, ch_types="eeg"
+    )
+    raw = mne.io.RawArray(data, info)
+
+    # Ensure there are no bad channels
+    raw.info["bads"] = []
+
+    # Use caplog to capture the logging output
+    with caplog.at_level(logging.INFO):
+        _eeglab_interpolate_bads(raw)
+
+    # Assert that the appropriate log message was emitted
+    assert "No bad channels to interpolate." in caplog.text
+
+    # Verify that the function exits early without modifying the data
+    assert raw.info["bads"] == []
 
 
 def test_mat_round():

--- a/pyprep/utils.py
+++ b/pyprep/utils.py
@@ -2,7 +2,7 @@
 import math
 from cmath import sqrt
 
-import mne
+# import mne
 import numpy as np
 import scipy.interpolate
 from mne.surface import _normalize_vectors
@@ -355,8 +355,8 @@ def _eeglab_interpolate_bads(raw):
 
     """
     # Get the indices of good and bad EEG channels
-    eeg_chans = mne.pick_types(raw.info, eeg=True, exclude=[])
-    good_idx = mne.pick_types(raw.info, eeg=True, exclude="bads")
+    eeg_chans = raw.pick(picks="eeg", exclude=[])
+    good_idx = raw.pick(picks="eeg", exclude="bads")
     bad_idx = sorted(_set_diff(eeg_chans, good_idx))
 
     # Get the spatial coordinates of the good and bad electrodes


### PR DESCRIPTION
# PR Description
closes #151 
This PR:
changes all instances of `pick_types` with `raw.pick`. 
removes "import mne" from pyprep/utils.py and  pyprep/tests/test_prep_pipeline.py as they are no longer in use

# Merge Checklist
[ ] the PR has been reviewed and all comments are resolved
[ ] all [CI][what-is-ci] checks pass
[ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to automatically close an issue. [auto-close-documentation]
[ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [whats_new.rst][whats-new-file]
[ ] (if applicable): new contributors have added themselves to the authors list in the `CITATION.cff` file

