### PR TITLE
ENH: allow specifying ransac at class inst of NoisyChannels

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,11 +14,15 @@ repos:
       - id: check-docstring-first
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.0
+    rev: v0.12.3
     hooks:
       - id: ruff
+        name: ruff check --fix
+        files: ^(pyprep/|examples/|tests/)
         args: ["--fix"]
       - id: ruff-format
+        name: ruff format
+        files: ^(pyprep/|examples/|tests/)
 
   - repo: https://github.com/pappasam/toml-sort
     rev: v0.24.2

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -242,6 +242,7 @@ class NoisyChannels:
                 f"Overwriting `ransac` value. Was `{self.ransac}` at instantiation "
                 f"of NoisyChannels. Now setting to `{ransac}`."
             )
+            self.ransac = ransac
 
         # NOTE: Bad-by-NaN/flat is already run during init, no need to re-run here
         self.find_bad_by_deviation()


### PR DESCRIPTION
<!--Thanks for contributing-->
<!--If this is your first time, please make sure to read the contributing guideline-->
<!--https://github.com/sappelhoff/pyprep/blob/main/.github/CONTRIBUTING.md-->

# PR Description

This PR allows specifying `ransac` (True/False) not only when calling `find_all_bads`, but also at instantiation of the class `NoisyChannels`.

All changes here are fully backward compatible.


 <!--Please describe your pull request here.-->

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [ ] the PR has been reviewed and all comments are resolved
- [ ] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): the changes are documented in the changelog [changelog.rst][changelog]
- [ ] (if applicable): new contributors have added themselves to the authors list in the [`CITATION.cff`][citationcff] file


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[changelog]: https://github.com/sappelhoff/pyprep/blob/main/docs/changelog.rst
[citationcff]: https://github.com/sappelhoff/pyprep/blob/main/CITATION.cff
