### PR TITLE
ADD: bad_by_PSD method

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,7 @@ Version 0.6.0 (unreleased)
 
 Changelog
 ~~~~~~~~~
+- Added :meth:`~pyprep.NoisyChannels.find_bad_by_PSD` method for detecting channels with abnormally high or low power spectral density. This is a PyPREP-only feature not present in MATLAB PREP. (:gh:`145`)
 - Added ``reject_by_annotation`` parameter to :class:`~pyprep.PrepPipeline`, :class:`~pyprep.Reference`, and :class:`~pyprep.NoisyChannels` to exclude BAD-annotated time segments from channel quality assessment, by `Roy Eric Wieske`_ (:gh:`180`)
 - Users can now determine whether or not to use ``correlation`` as a method for finding bad channels in :meth:`~pyprep.NoisyChannels.find_all_bads` (defaults to True), by `Stefan Appelhoff`_ (:gh:`169`)
 - Manually marked bad channels are ignored for finding further bads (just like NaN and flat channels) in :meth:`~pyprep.NoisyChannels.find_all_bads`, by `Stefan Appelhoff`_ (:gh:`168`)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,7 +26,7 @@ Version 0.6.0 (unreleased)
 
 Changelog
 ~~~~~~~~~
-- Added :meth:`~pyprep.NoisyChannels.find_bad_by_PSD` method for detecting channels with abnormally high or low power spectral density. This is a PyPREP-only feature not present in MATLAB PREP. (:gh:`145`)
+- Added :meth:`~pyprep.NoisyChannels.find_bad_by_PSD` method for detecting channels with abnormally high or low power spectral density. This is a PyPREP-only feature not present in MATLAB PREP, by `Roy Eric Wieske`_ (:gh:`145`)
 - Added ``reject_by_annotation`` parameter to :class:`~pyprep.PrepPipeline`, :class:`~pyprep.Reference`, and :class:`~pyprep.NoisyChannels` to exclude BAD-annotated time segments from channel quality assessment, by `Roy Eric Wieske`_ (:gh:`180`)
 - Users can now determine whether or not to use ``correlation`` as a method for finding bad channels in :meth:`~pyprep.NoisyChannels.find_all_bads` (defaults to True), by `Stefan Appelhoff`_ (:gh:`169`)
 - Manually marked bad channels are ignored for finding further bads (just like NaN and flat channels) in :meth:`~pyprep.NoisyChannels.find_all_bads`, by `Stefan Appelhoff`_ (:gh:`168`)

--- a/docs/matlab_differences.rst
+++ b/docs/matlab_differences.rst
@@ -245,7 +245,10 @@ Bad channel detection by PSD
 
 The :meth:`~pyprep.NoisyChannels.find_bad_by_PSD` method detects channels with
 abnormally high or low power spectral density (PSD) compared to other channels.
-This method is not part of the original MATLAB PREP pipeline.
+This method is not part of the original MATLAB PREP pipeline, but can be
+considered a refinement of the ``bad_by_hfnoise`` detection in MATLAB PREP,
+which flags channels based on the ratio of high-frequency power (>50 Hz) to
+total power.
 
 A channel is considered "bad-by-PSD" if its total PSD (computed using Welch's
 method over a configurable frequency range, defaulting to 1-45 Hz to exclude

--- a/docs/matlab_differences.rst
+++ b/docs/matlab_differences.rst
@@ -233,6 +233,30 @@ MATLAB PREP, PyPREP will use a Python reimplementation of ``eeg_interp`` instead
 when the ``matlab_strict`` parameter is set to ``True``.
 
 
+PyPREP-Only Features
+--------------------
+
+The following features are available in PyPREP but are not present in the
+original MATLAB PREP implementation.
+
+
+Bad channel detection by PSD
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :meth:`~pyprep.NoisyChannels.find_bad_by_PSD` method detects channels with
+abnormally high or low power spectral density (PSD) compared to other channels.
+This method is not part of the original MATLAB PREP pipeline.
+
+A channel is considered "bad-by-PSD" if its total PSD (computed using Welch's
+method over a configurable frequency range, defaulting to 1-45 Hz to exclude
+line noise) deviates considerably from the median channel PSD. The deviation
+is calculated using robust Z-scoring based on the median absolute deviation
+(MAD).
+
+This method is not called by :meth:`~pyprep.NoisyChannels.find_all_bads` by
+default and must be called explicitly if desired.
+
+
 Annotation-Based Segment Rejection
 ----------------------------------
 

--- a/docs/matlab_differences.rst
+++ b/docs/matlab_differences.rst
@@ -256,8 +256,9 @@ line noise) deviates considerably from the median channel PSD. The deviation
 is calculated using robust Z-scoring based on the median absolute deviation
 (MAD).
 
-This method is not called by :meth:`~pyprep.NoisyChannels.find_all_bads` by
-default and must be called explicitly if desired.
+This method is called by :meth:`~pyprep.NoisyChannels.find_all_bads` by default,
+but is skipped when ``matlab_strict=True`` to maintain equivalence with the
+original MATLAB PREP pipeline.
 
 
 Annotation-Based Segment Rejection

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -362,6 +362,8 @@ class NoisyChannels:
         if self.correlation:
             self.find_bad_by_correlation()
         self.find_bad_by_SNR()
+        if not self.matlab_strict:
+            self.find_bad_by_PSD()
         if self.ransac:
             self.find_bad_by_ransac(
                 channel_wise=channel_wise, max_chunk_size=max_chunk_size

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -6,8 +6,7 @@
 import mne
 import numpy as np
 from mne.utils import check_random_state, logger
-from scipy import signal
-from scipy.stats import median_abs_deviation
+from scipy import signal, stats
 
 from pyprep.ransac import find_bad_by_ransac
 from pyprep.removeTrend import removeTrend
@@ -153,6 +152,7 @@ class NoisyChannels:
             "bad_by_hf_noise": {},
             "bad_by_correlation": {},
             "bad_by_dropout": {},
+            "bad_by_psd": {},
             "bad_by_ransac": {},
         }
 
@@ -167,6 +167,7 @@ class NoisyChannels:
         self.bad_by_correlation = []
         self.bad_by_SNR = []
         self.bad_by_dropout = []
+        self.bad_by_psd = []
         self.bad_by_ransac = []
 
         # Get original EEG channel names, channel count & samples
@@ -621,6 +622,46 @@ class NoisyChannels:
 
         # Flag channels bad by both HF noise and low correlation as bad by low SNR
         self.bad_by_SNR = list(bad_by_corr.intersection(bad_by_hf))
+
+    def find_bad_by_PSD(self, zscore_threshold=3.0):
+        """
+        Detect channels with abnormally high or low overall power spectral density
+        (PSD) values.
+
+        A channel is considered "bad-by-psd" if its psd value deviates
+        considerably from the median channel psd, as calculated using a
+        Z-scoring method and the given z-score threshold.
+        PSD calculation is done using the Welch method.
+        Uses the Welch method for PSD calculation
+
+        Parameters
+        ----------
+        zscore_threshold : float, optional
+            The minimum noisiness z-score of a channel for it to be considered
+            bad-by-psd. Defaults to ``3.0``.
+        """
+        if self.EEGFiltered is None:
+            self.EEGFiltered = self._get_filtered_data()
+        psd = self.EEGFiltered.compute_psd(method='welch', fmin=1, fmax=50)
+        log_psd = 10 * np.log10(psd.get_data())
+        median_channel_psd = np.median(log_psd, axis=0)
+
+        #  # Calculate robust Z-scores for the channel amplitudes
+        psd_zscore = np.zeros(self.n_chans_original)
+        psd_zscore[self.usable_idx] = stats.zscore(np.sum(log_psd - median_channel_psd, axis=1))
+
+        # Flag channels with unusually high or low PSD values compared to the median channel
+        psd_channel_mask = np.isnan(psd_zscore) | (psd_zscore > zscore_threshold)
+        abnormal_psd_channels = self.ch_names_original[psd_channel_mask]
+
+        # Update names of bad channels by abnormal PSD & save additional info
+        self.bad_by_psd = abnormal_psd_channels.tolist()
+        self._extra_info["bad_by_psd"].update(
+            {
+                "median_channel_psd": median_channel_psd,
+                "psd_zscore": psd_zscore,
+            }
+        )
 
     def find_bad_by_ransac(
         self,

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -641,9 +641,7 @@ class NoisyChannels:
         1. Its power in any frequency band (low: 1-15 Hz, mid: 15-30 Hz,
            high: 30-45 Hz) deviates considerably from other channels, OR
         2. Its high-frequency band has more power than its low-frequency band
-           (violating the typical 1/f spectral profile of EEG), OR
-        3. Any ratio between frequency bands is abnormal compared to other
-           channels (e.g., low/mid, low/high, mid/high).
+           (violating the typical 1/f spectral profile of EEG).
 
         PSD is computed using Welch's method over the specified frequency range.
         The default range (1-45 Hz) excludes line noise frequencies (50/60 Hz).
@@ -739,8 +737,10 @@ class NoisyChannels:
             | (np.abs(zscore_ratio_mid_high) > zscore_threshold)
         )
 
-        # Combine all criteria (bad if ANY criterion is met)
-        bad_by_psd_usable = bad_by_band | bad_by_1f_violation | bad_by_ratio
+        # Combine criteria (bad if ANY criterion is met)
+        # Note: bad_by_ratio is computed for diagnostics but not used in final
+        # decision as it tends to be overly sensitive and theoretically debatable
+        bad_by_psd_usable = bad_by_band | bad_by_1f_violation
 
         # Map back to original channel indices
         psd_channel_mask = np.zeros(self.n_chans_original, dtype=bool)

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -251,6 +251,7 @@ class Reference:
             "bad_by_correlation": [],
             "bad_by_SNR": [],
             "bad_by_dropout": [],
+            "bad_by_psd": [],
             "bad_by_ransac": [],
             "bad_by_manual": self.bads_manual,
             "bad_all": [],

--- a/tests/test_find_noisy_channels.py
+++ b/tests/test_find_noisy_channels.py
@@ -258,7 +258,9 @@ def test_bad_by_PSD(raw_tmp):
     nd = NoisyChannels(raw_tmp, do_detrend=False)
     nd.find_bad_by_PSD()
     assert raw_tmp.ch_names[high_psd_idx] in nd.bad_by_psd
-    assert raw_tmp.ch_names[low_psd_idx] in nd.bad_by_psd
+    assert (
+        raw_tmp.ch_names[low_psd_idx] not in nd.bad_by_psd
+    )  # the low PSD criterion was ommitted
 
     # verify that bad_by_psd is included in get_bads() output
     all_bads = nd.get_bads(as_dict=True)


### PR DESCRIPTION
<!--Thanks for contributing-->
<!--If this is your first time, please make sure to read the contributing guideline-->
<!--https://github.com/sappelhoff/pyprep/blob/main/.github/CONTRIBUTING.md-->

# PR Description
Building on @nabilalibou's work (https://github.com/sappelhoff/pyprep/pull/145), this PR adds functionality for finding bad channels using Power Spectral Density (PSD). This method is not part of the original MATLAB PREP pipeline and only runs when matlab_strict=False.

## Detection Criteria
A channel is flagged as "bad-by-PSD" if either:
1. Abnormally high band power: The channel has an outlier z-score (>3.0) in any of three frequency bands:
    - Low (1-15 Hz): delta, theta, alpha
    - Mid (15-30 Hz): beta
    - High (30-45 Hz): gamma
2. 1/f violation: The high-frequency band has more power than the low-frequency band, which violates the typical 1/f spectral profile of EEG and often indicates muscle artifact or poor electrode contact.


## Implementation Details
- PSD is computed using Welch's method over 1-45 Hz (configurable via fmin/fmax)
- Default frequency range excludes 50/60 Hz line noise
- Uses MAD-based robust z-scoring (scaled by 1.4826 to convert to SD units)
- Only flags positive z-scores (excess power), as abnormally low power may reflect normal topographic variation


## Changes from previous PR (#145)
1. Detects only high PSD (not low), since low power can be normal
2. Uses MAD-based robust statistics instead of standard z-scoring
3. Splits spectrum into three frequency bands instead of total power
4. Adds 1/f violation criterion to catch muscle artifacts
5. Includes bad_by_psd in the bad channels dictionary
6. Fixes KeyError in Reference.robust_reference() by adding bad_by_psd to the noisy channels tracking dict


- closes: https://github.com/sappelhoff/pyprep/pull/145

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [ ] the PR has been reviewed and all comments are resolved
- [ ] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): the changes are documented in the changelog [changelog.rst][changelog]
- [ ] (if applicable): new contributors have added themselves to the authors list in the [`CITATION.cff`][citationcff] file


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[changelog]: https://github.com/sappelhoff/pyprep/blob/main/docs/changelog.rst
[citationcff]: https://github.com/sappelhoff/pyprep/blob/main/CITATION.cff
