### PR TITLE
ADD: reject_by_annotation to NoisyChannels

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -55,6 +55,10 @@ authors:
       family-names: Veillette
       affiliation: 'Department of Psychology, University of Chicago, Chicago, IL, USA'
       orcid: 'https://orcid.org/0000-0002-0332-4372'
+    - given-names: Roy Eric
+      family-names: Wieske
+      affiliation: 'Biopsychology and Neuroergonomics, Technische Universität Berlin, Berlin, Germany'
+      orcid: 'https://orcid.org/0009-0006-2018-1074'
 type: software
 repository-code: 'https://github.com/sappelhoff/pyprep'
 license: MIT

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -11,3 +11,4 @@
 .. _Victor Xiang: https://github.com/Nick3151
 .. _Yorguin Mantilla: https://github.com/yjmantilla
 .. _John Veillette: https://github.com/john-veillette
+.. _Roy Eric Wieske: https://github.com/Randomidous

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,7 @@ Version 0.6.0 (unreleased)
 
 Changelog
 ~~~~~~~~~
+- Added ``reject_by_annotation`` parameter to :class:`~pyprep.PrepPipeline`, :class:`~pyprep.Reference`, and :class:`~pyprep.NoisyChannels` to exclude BAD-annotated time segments from channel quality assessment, by `Roy Eric Wieske`_ (:gh:`180`)
 - Users can now determine whether or not to use ``correlation`` as a method for finding bad channels in :meth:`~pyprep.NoisyChannels.find_all_bads` (defaults to True), by `Stefan Appelhoff`_ (:gh:`169`)
 - Manually marked bad channels are ignored for finding further bads (just like NaN and flat channels) in :meth:`~pyprep.NoisyChannels.find_all_bads`, by `Stefan Appelhoff`_ (:gh:`168`)
 

--- a/docs/matlab_differences.rst
+++ b/docs/matlab_differences.rst
@@ -233,6 +233,32 @@ MATLAB PREP, PyPREP will use a Python reimplementation of ``eeg_interp`` instead
 when the ``matlab_strict`` parameter is set to ``True``.
 
 
+Annotation-Based Segment Rejection
+----------------------------------
+
+PyPREP supports the ``reject_by_annotation`` parameter in
+:class:`~pyprep.PrepPipeline`, :class:`~pyprep.Reference`, and
+:class:`~pyprep.NoisyChannels`, which allows excluding BAD-annotated time
+segments from channel quality assessment. This is useful when recordings
+contain breaks, movement artifacts, or other periods that shouldn't influence
+channel rejection decisions.
+
+MATLAB PREP does not have this feature. In fact, MATLAB PREP explicitly warns
+against using PREP on data with discontinuities (such as boundary markers from
+paused/resumed recordings). However, the ``reject_by_annotation`` feature in
+PyPREP is designed for a different use case: temporarily excluding known-bad
+segments (e.g., participant movement during breaks) from *statistical analysis*
+while preserving the original continuous data structure in the output.
+
+When ``reject_by_annotation`` is set to ``'omit'``, MNE's
+:meth:`~mne.io.Raw.get_data` is used to concatenate non-BAD segments for
+computing channel quality metrics. The final processed output retains the
+original continuous structure with all time points intact.
+
+This parameter has no equivalent in MATLAB PREP and is not affected by the
+``matlab_strict`` setting.
+
+
 References
 ----------
 

--- a/docs/matlab_differences.rst
+++ b/docs/matlab_differences.rst
@@ -239,7 +239,9 @@ Annotation-Based Segment Rejection
 PyPREP supports the ``reject_by_annotation`` parameter in
 :class:`~pyprep.PrepPipeline`, :class:`~pyprep.Reference`, and
 :class:`~pyprep.NoisyChannels`, which allows excluding BAD-annotated time
-segments from channel quality assessment. This is useful when recordings
+segments from channel quality assessment. BAD segments are any MNE annotations
+with descriptions starting with "BAD" or "bad" (see
+:ref:`mne:tut-reject-data-spans` for details). This is useful when recordings
 contain breaks, movement artifacts, or other periods that shouldn't influence
 channel rejection decisions.
 
@@ -254,6 +256,16 @@ When ``reject_by_annotation`` is set to ``'omit'``, MNE's
 :meth:`~mne.io.Raw.get_data` is used to concatenate non-BAD segments for
 computing channel quality metrics. The final processed output retains the
 original continuous structure with all time points intact.
+
+.. note::
+
+   This feature is intended for excluding a small number of longer segments
+   (e.g., recording breaks). Using it with many short BAD segments (e.g., from
+   automated muscle artifact detection via
+   :func:`mne.preprocessing.annotate_muscle_zscore`) may introduce edge effects
+   at concatenation boundaries, particularly for methods that apply filtering
+   to the concatenated data. PyPREP will emit a warning if many small BAD
+   segments are detected.
 
 This parameter has no equivalent in MATLAB PREP. When ``matlab_strict`` is set
 to ``True``, ``reject_by_annotation`` is automatically set to ``None``.

--- a/docs/matlab_differences.rst
+++ b/docs/matlab_differences.rst
@@ -255,7 +255,8 @@ When ``reject_by_annotation`` is set to ``'omit'``, MNE's
 computing channel quality metrics. The final processed output retains the
 original continuous structure with all time points intact.
 
-This parameter has no equivalent in MATLAB PREP. When ``matlab_strict`` is set to ``True``, ``reject_by_annotation`` is automatically set to ``None``.
+This parameter has no equivalent in MATLAB PREP. When ``matlab_strict`` is set
+to ``True``, ``reject_by_annotation`` is automatically set to ``None``.
 
 
 References

--- a/docs/matlab_differences.rst
+++ b/docs/matlab_differences.rst
@@ -255,8 +255,7 @@ When ``reject_by_annotation`` is set to ``'omit'``, MNE's
 computing channel quality metrics. The final processed output retains the
 original continuous structure with all time points intact.
 
-This parameter has no equivalent in MATLAB PREP and is not affected by the
-``matlab_strict`` setting.
+This parameter has no equivalent in MATLAB PREP. When ``matlab_strict`` is set to ``True``, ``reject_by_annotation`` is automatically set to ``None``.
 
 
 References

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -197,10 +197,10 @@ class NoisyChannels:
 
         Parameters
         ----------
-        verbose : bool, optional
+        verbose : bool | None
             If ``True``, a summary of the channels currently flagged as by bad per
             category is printed. Defaults to ``False``.
-        as_dict: bool, optional
+        as_dict: bool | None
             If ``True``, this method will return a dict of the channels currently
             flagged as bad by each individual bad channel type. If ``False``, this
             method will return a list of all unique bad channels detected so far.
@@ -268,7 +268,7 @@ class NoisyChannels:
             detection considerably. If ``None`` (default), then the value at
             instantiation of the ``NoisyChannels`` class is taken (defaults
             to ``True``), else the instantiation value is overwritten.
-        channel_wise : bool, optional
+        channel_wise : bool | None
             Whether RANSAC should predict signals for chunks of channels over the
             entire signal length ("channel-wise RANSAC", see `max_chunk_size`
             parameter). If ``False``, RANSAC will instead predict signals for all
@@ -278,7 +278,7 @@ class NoisyChannels:
             (especially if `max_chunk_size` is ``None``), but can be faster on
             systems with lots of RAM to spare. Has no effect if not using RANSAC.
             Defaults to ``False``.
-        max_chunk_size : {int, None}, optional
+        max_chunk_size : {int, None} | None
             The maximum number of channels to predict at once during
             channel-wise RANSAC. If ``None``, RANSAC will use the largest chunk
             size that will fit into the available RAM, which may slow down
@@ -345,7 +345,7 @@ class NoisyChannels:
 
         Parameters
         ----------
-        flat_threshold : float, optional
+        flat_threshold : float | None
             The lowest standard deviation or MAD value for a channel to be
             considered bad-by-flat. Defaults to ``1e-15`` volts (corresponds to
             10e-10 µV in MATLAB PREP).
@@ -382,7 +382,7 @@ class NoisyChannels:
 
         Parameters
         ----------
-        deviation_threshold : float, optional
+        deviation_threshold : float | None
             The minimum absolute z-score of a channel for it to be considered
             bad-by-deviation. Defaults to ``5.0``.
 
@@ -428,7 +428,7 @@ class NoisyChannels:
 
         Parameters
         ----------
-        HF_zscore_threshold : float, optional
+        HF_zscore_threshold : float | None
             The minimum noisiness z-score of a channel for it to be considered
             bad-by-high-frequency-noise. Defaults to ``5.0``.
 
@@ -493,12 +493,12 @@ class NoisyChannels:
 
         Parameters
         ----------
-        correlation_secs : float, optional
+        correlation_secs : float | None
             The length (in seconds) of each correlation window. Defaults to ``1.0``.
-        correlation_threshold : float, optional
+        correlation_threshold : float | None
             The lowest maximum inter-channel correlation for a channel to be
             considered "bad" within a given window. Defaults to ``0.4``.
-        frac_bad : float, optional
+        frac_bad : float | None
             The minimum proportion of bad windows for a channel to be considered
             "bad-by-correlation" or "bad-by-dropout". Defaults to ``0.01`` (1% of
             all windows).
@@ -637,26 +637,26 @@ class NoisyChannels:
 
         Parameters
         ----------
-        n_samples : int, optional
+        n_samples : int | None
             Number of random channel samples to use for RANSAC. Defaults
             to ``50``.
-        sample_prop : float, optional
+        sample_prop : float | None
             Proportion of total channels to use for signal prediction per RANSAC
             sample. This needs to be in the range [0, 1], where 0 would mean no
             channels would be used and 1 would mean all channels would be used
             (neither of which would be useful values). Defaults to ``0.25``
             (e.g., 16 channels per sample for a 64-channel dataset).
-        corr_thresh : float, optional
+        corr_thresh : float | None
             The minimum predicted vs. actual signal correlation for a channel to
             be considered good within a given RANSAC window. Defaults
             to ``0.75``.
-        frac_bad : float, optional
+        frac_bad : float | None
             The minimum fraction of bad (i.e., below-threshold) RANSAC windows
             for a channel to be considered bad-by-RANSAC. Defaults to ``0.4``.
-        corr_window_secs : float, optional
+        corr_window_secs : float | None
             The duration (in seconds) of each RANSAC correlation window. Defaults
             to 5 seconds.
-        channel_wise : bool, optional
+        channel_wise : bool | None
             Whether RANSAC should predict signals for chunks of channels over the
             entire signal length ("channel-wise RANSAC", see `max_chunk_size`
             parameter). If ``False``, RANSAC will instead predict signals for all
@@ -665,7 +665,7 @@ class NoisyChannels:
             RANSAC generally has higher RAM demands than window-wise RANSAC
             (especially if `max_chunk_size` is ``None``), but can be faster on
             systems with lots of RAM to spare. Defaults to ``False``.
-        max_chunk_size : {int, None}, optional
+        max_chunk_size : {int, None} | None
             The maximum number of channels to predict at once during
             channel-wise RANSAC. If ``None``, RANSAC will use the largest chunk
             size that will fit into the available RAM, which may slow down

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -118,6 +118,13 @@ class NoisyChannels:
                 f"reject_by_annotation must be None, 'omit', or 'NaN', "
                 f"got: {reject_by_annotation}"
             )
+        # reject_by_annotation is not available in MATLAB PREP
+        if matlab_strict and reject_by_annotation is not None:
+            logger.warning(
+                "reject_by_annotation is not available in MATLAB PREP. "
+                f"Setting reject_by_annotation to None (was '{reject_by_annotation}')."
+            )
+            reject_by_annotation = None
         self.reject_by_annotation = reject_by_annotation
 
         # Extra data for debugging

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -57,14 +57,14 @@ class NoisyChannels:
         List of channels that are bad. These channels will be excluded when
         trying to find additional bad channels. Note that the union of these channels
         and those declared in ``raw.info["bads"]`` will be used. Defaults to ``None``.
-    reject_by_annotation : {None, 'omit', 'NaN'} | None
+    reject_by_annotation : {None, 'omit'} | None
         How to handle BAD-annotated time segments (annotations starting with
         "BAD" or "bad") during channel quality assessment. If ``'omit'``,
         annotated segments are excluded from analysis (clean segments are
-        concatenated). If ``'NaN'``, annotated samples are replaced with NaN
-        values. If ``None`` (default), annotations are ignored and the full
-        recording is used. This is useful when recordings contain breaks or
-        movement artifacts that shouldn't influence channel rejection decisions.
+        concatenated). If ``None`` (default), annotations are ignored and the
+        full recording is used. This is useful when recordings contain breaks
+        or movement artifacts that shouldn't influence channel rejection
+        decisions.
 
     References
     ----------
@@ -110,12 +110,9 @@ class NoisyChannels:
         self.correlation = correlation
 
         # Validate reject_by_annotation parameter
-        if reject_by_annotation is not None and reject_by_annotation not in (
-            "omit",
-            "NaN",
-        ):
+        if reject_by_annotation is not None and reject_by_annotation != "omit":
             raise ValueError(
-                f"reject_by_annotation must be None, 'omit', or 'NaN', "
+                f"reject_by_annotation must be None or 'omit', "
                 f"got: {reject_by_annotation}"
             )
         # reject_by_annotation is not available in MATLAB PREP
@@ -320,7 +317,7 @@ class NoisyChannels:
             to the other methods. If ``None`` (default), then the value at
             instantiation of the ``NoisyChannels`` class is taken (defaults
             to ``True``), else the instantiation value is overwritten.
-        reject_by_annotation : {None, 'omit', 'NaN'} | None
+        reject_by_annotation : {None, 'omit'} | None
             This parameter is accepted for compatibility but is ignored here.
             Annotation rejection is applied during ``NoisyChannels`` initialization,
             not during ``find_all_bads``. To use annotation rejection, pass

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -140,7 +140,7 @@ class NoisyChannels:
                 recording_length = raw.times[-1]
                 bad_percentage = (total_bad_time / recording_length) * 100
                 mean_duration = total_bad_time / n_bad_segments
-                if bad_percentage > 10 and mean_duration < 5.0:
+                if bad_percentage > 15 and mean_duration < 5.0:
                     logger.warning(
                         f"Found {n_bad_segments} BAD segments covering "
                         f"{bad_percentage:.1f}% of the recording with mean duration "

--- a/pyprep/prep_pipeline.py
+++ b/pyprep/prep_pipeline.py
@@ -39,15 +39,15 @@ class PrepPipeline:
               For example, for 60Hz you may specify
               ``np.arange(60, sfreq / 2, 60)``. Specify an empty list to
               skip the line noise removal step.
-        - max_iterations : int, optional
+        - max_iterations : int | None
             - The maximum number of iterations of noisy channel removal to
               perform during robust referencing. Defaults to ``4``.
     montage : mne.channels.DigMontage
         Digital montage of EEG data.
-    ransac : bool, optional
+    ransac : bool | None
         Whether or not to use RANSAC for noisy channel detection in addition to
         the other methods in :class:`~pyprep.NoisyChannels`. Defaults to True.
-    channel_wise : bool, optional
+    channel_wise : bool | None
         Whether RANSAC should predict signals for chunks of channels over the
         entire signal length ("channel-wise RANSAC", see `max_chunk_size`
         parameter). If ``False``, RANSAC will instead predict signals for all
@@ -57,24 +57,24 @@ class PrepPipeline:
         (especially if `max_chunk_size` is ``None``), but can be faster on
         systems with lots of RAM to spare. Has no effect if not using RANSAC.
         Defaults to ``False``.
-    max_chunk_size : {int, None}, optional
+    max_chunk_size : {int, None} | None
         The maximum number of channels to predict at once during channel-wise
         RANSAC. If ``None``, RANSAC will use the largest chunk size that will
         fit into the available RAM, which may slow down other programs on the
         host system. If using window-wise RANSAC (the default) or not using
         RANSAC at all, this parameter has no effect. Defaults to ``None``.
-    random_state : {int, None, np.random.RandomState}, optional
+    random_state : {int, None, np.random.RandomState} | None
         The random seed at which to initialize the class. If random_state is
         an int, it will be used as a seed for RandomState.
         If None, the seed will be obtained from the operating system
         (see RandomState for details). Default is None.
-    filter_kwargs : {dict, None}, optional
+    filter_kwargs : {dict, None} | None
         Optional keywords arguments to be passed on to mne.filter.notch_filter.
         Do not set the "x", Fs", and "freqs" arguments via the filter_kwargs
         parameter, but use the "raw" and "prep_params" parameters instead.
         If None is passed, the pyprep default settings for filtering are used
         instead.
-    reject_by_annotation : {None, 'omit', 'NaN'}, optional
+    reject_by_annotation : {None, 'omit', 'NaN'} | None
         How to handle BAD-annotated time segments during channel quality
         assessment. If ``'omit'``, annotated segments are excluded from
         analysis (clean segments are concatenated). If ``'NaN'``, annotated
@@ -82,7 +82,7 @@ class PrepPipeline:
         are ignored and the full recording is used. This is useful when recordings
         contain breaks or movement artifacts that shouldn't influence channel
         rejection decisions.
-    matlab_strict : bool, optional
+    matlab_strict : bool | None
         Whether or not PyPREP should strictly follow MATLAB PREP's internal
         math, ignoring any improvements made in PyPREP over the original code
         (see :ref:`matlab-diffs` for more details). Defaults to False.

--- a/pyprep/prep_pipeline.py
+++ b/pyprep/prep_pipeline.py
@@ -74,14 +74,14 @@ class PrepPipeline:
         parameter, but use the "raw" and "prep_params" parameters instead.
         If None is passed, the pyprep default settings for filtering are used
         instead.
-    reject_by_annotation : {None, 'omit', 'NaN'} | None
-        How to handle BAD-annotated time segments during channel quality
-        assessment. If ``'omit'``, annotated segments are excluded from
-        analysis (clean segments are concatenated). If ``'NaN'``, annotated
-        samples are replaced with NaN values. If ``None`` (default), annotations
-        are ignored and the full recording is used. This is useful when recordings
-        contain breaks or movement artifacts that shouldn't influence channel
-        rejection decisions.
+    reject_by_annotation : {None, 'omit'} | None
+        How to handle BAD-annotated time segments (annotations starting with
+        "BAD" or "bad") during channel quality assessment. If ``'omit'``,
+        annotated segments are excluded from analysis (clean segments are
+        concatenated). If ``None`` (default), annotations are ignored and the
+        full recording is used. This is useful when recordings contain breaks
+        or movement artifacts that shouldn't influence channel rejection
+        decisions.
     matlab_strict : bool | None
         Whether or not PyPREP should strictly follow MATLAB PREP's internal
         math, ignoring any improvements made in PyPREP over the original code

--- a/pyprep/prep_pipeline.py
+++ b/pyprep/prep_pipeline.py
@@ -74,6 +74,14 @@ class PrepPipeline:
         parameter, but use the "raw" and "prep_params" parameters instead.
         If None is passed, the pyprep default settings for filtering are used
         instead.
+    reject_by_annotation : {None, 'omit', 'NaN'}, optional
+        How to handle BAD-annotated time segments during channel quality
+        assessment. If ``'omit'``, annotated segments are excluded from
+        analysis (clean segments are concatenated). If ``'NaN'``, annotated
+        samples are replaced with NaN values. If ``None`` (default), annotations
+        are ignored and the full recording is used. This is useful when recordings
+        contain breaks or movement artifacts that shouldn't influence channel
+        rejection decisions.
     matlab_strict : bool, optional
         Whether or not PyPREP should strictly follow MATLAB PREP's internal
         math, ignoring any improvements made in PyPREP over the original code
@@ -128,6 +136,7 @@ class PrepPipeline:
         max_chunk_size=None,
         random_state=None,
         filter_kwargs=None,
+        reject_by_annotation=None,
         matlab_strict=False,
     ):
         """Initialize PREP class."""
@@ -167,6 +176,7 @@ class PrepPipeline:
             "ransac": ransac,
             "channel_wise": channel_wise,
             "max_chunk_size": max_chunk_size,
+            "reject_by_annotation": reject_by_annotation,
         }
         self.random_state = check_random_state(random_state)
         self.filter_kwargs = filter_kwargs

--- a/pyprep/ransac.py
+++ b/pyprep/ransac.py
@@ -60,24 +60,24 @@ def find_bad_by_ransac(
     exclude : list
         Labels of channels to exclude as signal predictors during RANSAC
         (i.e., channels already flagged as bad by metrics other than HF noise).
-    n_samples : int, optional
+    n_samples : int | None
         Number of random channel samples to use for RANSAC. Defaults to ``50``.
-    sample_prop : float, optional
+    sample_prop : float | None
         Proportion of total channels to use for signal prediction per RANSAC
         sample. This needs to be in the range [0, 1], where 0 would mean no
         channels would be used and 1 would mean all channels would be used
         (neither of which would be useful values). Defaults to ``0.25`` (e.g.,
         16 channels per sample for a 64-channel dataset).
-    corr_thresh : float, optional
+    corr_thresh : float | None
         The minimum predicted vs. actual signal correlation for a channel to
         be considered good within a given RANSAC window. Defaults to ``0.75``.
-    frac_bad : float, optional
+    frac_bad : float | None
         The minimum fraction of bad (i.e., below-threshold) RANSAC windows for a
         channel to be considered bad-by-RANSAC. Defaults to ``0.4``.
-    corr_window_secs : float, optional
+    corr_window_secs : float | None
         The duration (in seconds) of each RANSAC correlation window. Defaults to
         5 seconds.
-    channel_wise : bool, optional
+    channel_wise : bool | None
         Whether RANSAC should predict signals for chunks of channels over the
         entire signal length ("channel-wise RANSAC", see `max_chunk_size`
         parameter). If ``False``, RANSAC will instead predict signals for all
@@ -86,18 +86,18 @@ def find_bad_by_ransac(
         RANSAC generally has higher RAM demands than window-wise RANSAC
         (especially if `max_chunk_size` is ``None``), but can be faster on
         systems with lots of RAM to spare. Defaults to ``False``.
-    max_chunk_size : {int, None}, optional
+    max_chunk_size : {int, None} | None
         The maximum number of channels to predict at once during channel-wise
         RANSAC. If ``None``, RANSAC will use the largest chunk size that will
         fit into the available RAM, which may slow down other programs on the
         host system. If using window-wise RANSAC (the default), this parameter
         has no effect. Defaults to ``None``.
-    random_state : {int, None, np.random.RandomState}, optional
+    random_state : {int, None, np.random.RandomState} | None
         The random seed with which to generate random samples of channels during
         RANSAC. If random_state is an int, it will be used as a seed for RandomState.
         If ``None``, the seed will be obtained from the operating system
         (see RandomState for details). Defaults to ``None``.
-    matlab_strict : bool, optional
+    matlab_strict : bool | None
         Whether or not RANSAC should strictly follow MATLAB PREP's internal
         math, ignoring any improvements made in PyPREP over the original code
         (see :ref:`matlab-diffs` for more details). Defaults to ``False``.

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -32,10 +32,10 @@ class Reference:
         Parameters of PREP which include at least the following keys:
         - ``ref_chs``
         - ``reref_chs``
-    ransac : bool, optional
+    ransac : bool | None
         Whether or not to use RANSAC for noisy channel detection in addition to
         the other methods in :class:`~pyprep.NoisyChannels`. Defaults to True.
-    channel_wise : bool, optional
+    channel_wise : bool | None
         Whether RANSAC should predict signals for chunks of channels over the
         entire signal length ("channel-wise RANSAC", see `max_chunk_size`
         parameter). If ``False``, RANSAC will instead predict signals for all
@@ -45,22 +45,22 @@ class Reference:
         (especially if `max_chunk_size` is ``None``), but can be faster on
         systems with lots of RAM to spare. Has no effect if not using RANSAC.
         Defaults to ``False``.
-    max_chunk_size : {int, None}, optional
+    max_chunk_size : {int, None} | None
         The maximum number of channels to predict at once during channel-wise
         RANSAC. If ``None``, RANSAC will use the largest chunk size that will
         fit into the available RAM, which may slow down other programs on the
         host system. If using window-wise RANSAC (the default) or not using
         RANSAC at all, this parameter has no effect. Defaults to ``None``.
-    random_state : {int, None, np.random.RandomState}, optional
+    random_state : {int, None, np.random.RandomState} | None
         The random seed at which to initialize the class. If random_state is
         an int, it will be used as a seed for RandomState.
         If None, the seed will be obtained from the operating system
         (see RandomState for details). Default is None.
-    reject_by_annotation : {None, 'omit', 'NaN'}, optional
+    reject_by_annotation : {None, 'omit', 'NaN'} | None
         How to handle BAD-annotated time segments during channel quality
         assessment. If ``'omit'``, annotated segments are excluded. If ``'NaN'``,
         annotated samples are replaced with NaN. Defaults to ``None`` (ignore).
-    matlab_strict : bool, optional
+    matlab_strict : bool | None
         Whether or not PyPREP should strictly follow MATLAB PREP's internal
         math, ignoring any improvements made in PyPREP over the original code.
         Defaults to False.
@@ -110,7 +110,7 @@ class Reference:
 
         Parameters
         ----------
-        max_iterations : int, optional
+        max_iterations : int | None
             The maximum number of iterations of noisy channel removal to perform
             during robust referencing. Defaults to ``4``.
 
@@ -204,7 +204,7 @@ class Reference:
 
         Parameters
         ----------
-        max_iterations : int, optional
+        max_iterations : int | None
             The maximum number of iterations of noisy channel removal to perform
             during robust referencing. Defaults to ``4``.
 
@@ -352,7 +352,7 @@ class Reference:
             The original EEG signal.
         reference : np.ndarray, shape(times,)
             The reference signal.
-        index : {list, None}, optional
+        index : {list, None} | None
             A list of channel indices from which the reference signal should be
             subtracted. Defaults to all channels in `signal`.
 

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -56,10 +56,10 @@ class Reference:
         an int, it will be used as a seed for RandomState.
         If None, the seed will be obtained from the operating system
         (see RandomState for details). Default is None.
-    reject_by_annotation : {None, 'omit', 'NaN'} | None
-        How to handle BAD-annotated time segments during channel quality
-        assessment. If ``'omit'``, annotated segments are excluded. If ``'NaN'``,
-        annotated samples are replaced with NaN. Defaults to ``None`` (ignore).
+    reject_by_annotation : {None, 'omit'} | None
+        How to handle BAD-annotated time segments (annotations starting with
+        "BAD" or "bad") during channel quality assessment. If ``'omit'``,
+        annotated segments are excluded. Defaults to ``None`` (ignore).
     matlab_strict : bool | None
         Whether or not PyPREP should strictly follow MATLAB PREP's internal
         math, ignoring any improvements made in PyPREP over the original code.

--- a/pyprep/removeTrend.py
+++ b/pyprep/removeTrend.py
@@ -27,16 +27,16 @@ def removeTrend(
         A 2-D array of EEG data to detrend.
     sample_rate : float
         The sample rate (in Hz) of the input EEG data.
-    detrendType : str, optional
+    detrendType : str | None
         Type of detrending to be performed: must be one of 'high pass',
         'high pass sinc, or 'local detrend'. Defaults to 'high pass'.
-    detrendCutoff : float, optional
+    detrendCutoff : float | None
         The high-pass cutoff frequency (in Hz) to use for detrending. Defaults
         to 1.0 Hz.
-    detrendChannels : {list, None}, optional
+    detrendChannels : {list, None} | None
         List of the indices of all channels that require detrending/filtering.
         If ``None``, all channels are used (default).
-    matlab_strict : bool, optional
+    matlab_strict : bool | None
         Whether or not detrending should strictly follow MATLAB PREP's internal
         math, ignoring any improvements made in PyPREP over the original code
         (see :ref:`matlab-diffs` for more details). Defaults to ``False``.

--- a/pyprep/utils.py
+++ b/pyprep/utils.py
@@ -56,7 +56,7 @@ def _mat_quantile(arr, q, axis=None):
     q : float
         The quantile to calculate for the input data. Must be between 0 and 1,
         inclusive.
-    axis : {int, tuple of int, None}, optional
+    axis : {int, tuple of int, None} | None
         Axis along which quantile values should be calculated. Defaults to
         calculating the value at the given quantile for the entire array.
 
@@ -130,7 +130,7 @@ def _mat_iqr(arr, axis=None):
     ----------
     arr : np.ndarray
         Input array containing samples from the distribution to summarize.
-    axis : {int, tuple of int, None}, optional
+    axis : {int, tuple of int, None} | None
         Axis along which IQRs should be calculated. Defaults to calculating the
         IQR for the entire array.
 
@@ -435,7 +435,7 @@ def _correlate_arrays(a, b, matlab_strict=False):
         A 2-D array to correlate with `a`.
     b : np.ndarray
         A 2-D array to correlate with `b`.
-    matlab_strict : bool, optional
+    matlab_strict : bool | None
         Whether or not correlations should be calculated identically to MATLAB
         PREP (i.e., without mean subtraction) instead of by traditional Pearson
         product-moment correlation (see Notes for details). Defaults to

--- a/tests/test_find_noisy_channels.py
+++ b/tests/test_find_noisy_channels.py
@@ -309,14 +309,6 @@ def test_find_bad_by_ransac_err(raw_tmp):
 # Tests for reject_by_annotation functionality
 
 
-def test_reject_by_annotation_default(raw_tmp):
-    """Test that default behavior (None) doesn't change sample count."""
-    nd = NoisyChannels(raw_tmp, do_detrend=False, reject_by_annotation=None)
-    expected_samples = raw_tmp.get_data().shape[1]
-    assert nd.n_samples == expected_samples
-    assert nd.n_samples_original == expected_samples
-
-
 def test_reject_by_annotation_omit(raw_tmp):
     """Test that 'omit' mode excludes annotated segments."""
     # Add a BAD annotation covering 10% of the recording

--- a/tests/test_find_noisy_channels.py
+++ b/tests/test_find_noisy_channels.py
@@ -331,24 +331,6 @@ def test_reject_by_annotation_omit(raw_tmp):
     assert nd_no_reject.n_samples == original_samples
 
 
-def test_reject_by_annotation_nan(raw_tmp):
-    """Test that 'NaN' mode replaces annotated samples with NaN."""
-    # Add a BAD annotation
-    duration = raw_tmp.times[-1]
-    raw_tmp.annotations.append(
-        onset=duration * 0.4,
-        duration=duration * 0.1,
-        description="BAD_test",
-    )
-
-    original_samples = raw_tmp.get_data().shape[1]
-
-    # With 'NaN', sample count should be preserved but data should have NaNs
-    nd = NoisyChannels(raw_tmp, do_detrend=False, reject_by_annotation="NaN")
-    assert nd.n_samples == original_samples
-    assert np.any(np.isnan(nd.EEGData))
-
-
 def test_reject_by_annotation_invalid(raw_tmp):
     """Test that invalid reject_by_annotation values raise ValueError."""
     with pytest.raises(ValueError, match="reject_by_annotation must be"):


### PR DESCRIPTION
<!--Thanks for contributing-->
<!--If this is your first time, please make sure to read the contributing guideline-->
<!--https://github.com/sappelhoff/pyprep/blob/main/.github/CONTRIBUTING.md-->

# PR Description
Following a discussion [here](https://github.com/sappelhoff/pyprep/issues/108) and [there](https://github.com/sappelhoff/pyprep/issues/133), this PR implements mne's reject_by_annotation to exclude BAD-annotated time segments from channel quality assessment. Bad segments (e.g., participant movement during breaks) are only temporarily excluded from *statistical analysis* while preserving the original continuous data structure in the output. 

Note:
- This has not been tested
- I recommend looking at the changes commit by commit, since there is also a formatting commit changing a lot of things :) 
- closes: https://github.com/sappelhoff/pyprep/issues/108
- closes: https://github.com/sappelhoff/pyprep/issues/133


 <!--Please describe your pull request here.-->

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [ ] the PR has been reviewed and all comments are resolved
- [ ] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): the changes are documented in the changelog [changelog.rst][changelog]
- [ ] (if applicable): new contributors have added themselves to the authors list in the [`CITATION.cff`][citationcff] file


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[changelog]: https://github.com/sappelhoff/pyprep/blob/main/docs/changelog.rst
[citationcff]: https://github.com/sappelhoff/pyprep/blob/main/CITATION.cff
