### PR TITLE
 FIX: let get_data always consider reject_by_annotation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,7 +26,7 @@ Version 0.7.0 (unreleased)
 
 Changelog
 ~~~~~~~~~
-- nothing yet
+- :meth:`~pyprep.NoisyChannels.find_bad_by_nan_flat` now respects the ``reject_by_annotation`` setting of the :class:`~pyprep.NoisyChannels` instance, consistent with all other detection methods, by `Roy Eric Wieske`_ (:gh:`185`)
 
 .. _changes_0_6_0:
 

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -175,7 +175,7 @@ class NoisyChannels:
         ch_names = np.asarray(self.raw_mne.info["ch_names"])
         self.ch_names_original = ch_names
         self.n_chans_original = len(ch_names)
-        self.n_samples_original = raw.get_data().shape[1]
+        self.n_samples_original = raw.n_times
 
         # Before anything else, flag bad-by-NaNs and bad-by-flats
         self.find_bad_by_nan_flat()

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -378,7 +378,9 @@ class NoisyChannels:
 
         This method is run automatically when a ``NoisyChannels`` object is
         initialized, preventing flat or NaN-containing channels from interfering
-        with the detection of other types of bad channels.
+        with the detection of other types of bad channels. The
+        ``reject_by_annotation`` setting of the :class:`NoisyChannels` instance
+        is respected when retrieving the data.
 
         Parameters
         ----------

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -388,7 +388,7 @@ class NoisyChannels:
             10e-10 µV in MATLAB PREP).
         """
         # Get all EEG channels from original copy of data
-        EEGData = self.raw_mne.get_data()
+        EEGData = self.raw_mne.get_data(reject_by_annotation=self.reject_by_annotation)
 
         # Detect channels containing any NaN values
         nan_channel_mask = np.isnan(np.sum(EEGData, axis=1))


### PR DESCRIPTION
<!--Thanks for contributing-->
<!--If this is your first time, please make sure to read the contributing guideline-->
<!--https://github.com/sappelhoff/pyprep/blob/main/.github/CONTRIBUTING.md-->

# PR Description
- Updating the get_data call in find_bad_by_nan_flat to consider reject_by_annotation.
- closes: https://github.com/sappelhoff/pyprep/issues/184


 <!--Please describe your pull request here.-->

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [ ] the PR has been reviewed and all comments are resolved
- [ ] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): the changes are documented in the changelog [changelog.rst][changelog]
- [ ] (if applicable): new contributors have added themselves to the authors list in the [`CITATION.cff`][citationcff] file


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[changelog]: https://github.com/sappelhoff/pyprep/blob/main/docs/changelog.rst
[citationcff]: https://github.com/sappelhoff/pyprep/blob/main/CITATION.cff
