### PR TITLE
FIX: fetch test recording via MNE eegbci loader; resilient package downloads

### DIFF
--- a/.github/workflows/matprep_artifacts.yml
+++ b/.github/workflows/matprep_artifacts.yml
@@ -38,6 +38,11 @@ jobs:
       with:
         python-version: '3.12'
 
+    - name: Install Python dependencies
+      # mne (eegbci loader) is used only to fetch the test recording; it does
+      # not touch the artifact values -- MATLAB PREP does all the processing.
+      run: python -m pip install --upgrade pip mne
+
     - name: Download MATLAB packages and test data
       run: python config/pipeline_setup.py
 

--- a/tools/matprep/config/pipeline_setup.py
+++ b/tools/matprep/config/pipeline_setup.py
@@ -10,14 +10,17 @@ from urllib.error import URLError
 from urllib.request import Request, urlopen
 from zipfile import ZipFile
 
+from mne.datasets import eegbci
+
 
 def download(url, dest, retries=5, timeout=60):
     """Download ``url`` to ``dest``, retrying on transient network errors.
 
-    A single ``urlopen`` with no timeout is fragile in CI: a momentary
-    runner-to-host connectivity blip (e.g. an IPv6 route that blackholes the
-    connection) hangs for the full kernel timeout and then kills the build. So
-    bound each attempt with a timeout and retry a few times with backoff. A
+    Used for the EEGLAB/PREP software archives (the EEG recording itself is
+    fetched via MNE's ``eegbci`` loader). A single ``urlopen`` with no timeout
+    is fragile in CI: a momentary connectivity blip (e.g. an IPv6 route that
+    blackholes the connection) hangs for the full kernel timeout and then kills
+    the build. So bound each attempt with a timeout and retry with backoff. A
     browser-like ``User-Agent`` is sent because some servers reject the default
     ``Python-urllib`` agent.
 
@@ -60,17 +63,20 @@ download_dir.mkdir(exist_ok=True)
 package_dir.mkdir(exist_ok=True)
 artifact_dir.mkdir(exist_ok=True)
 
-# Download test EEG data (currently using S004R01 from the BCI2000 dataset)
+# Download test EEG data (S004R01 from the BCI2000 / EEGBCI dataset).
+#
+# Fetched via MNE's eegbci loader rather than a raw download: it is pooch-backed
+# (retries on transient failures and verifies the bytes against MNE's hash
+# registry) and pulls the recording from the same PhysioNet source the rest of
+# pyprep's test suite uses, so both sides see the identical file.
 
-subject = "S004"
-run = "R01"
-eeg_filename = f"{subject}{run}.edf"
-eeg_url = (
-    f"https://www.physionet.org/files/eegmmidb/1.0.0/{subject}/{eeg_filename}?download"
-)
+subject = 4
+run = 1
+eeg_filename = f"S{subject:03d}R{run:02d}.edf"
 
 print("* Downloading EEG test data...")
-download(eeg_url, eeg_filename)
+eeg_paths = eegbci.load_data(subject, run, path=str(package_dir), update_path=False)
+shutil.copy(eeg_paths[0], eeg_filename)
 
 # Download and extract EEGLAB and MATLAB PREP.
 #

--- a/tools/matprep/config/pipeline_setup.py
+++ b/tools/matprep/config/pipeline_setup.py
@@ -4,10 +4,51 @@
 #          Stefan Appelhoff
 
 import shutil
+import time
 from pathlib import Path
-from urllib.error import HTTPError, URLError
-from urllib.request import urlopen
+from urllib.error import URLError
+from urllib.request import Request, urlopen
 from zipfile import ZipFile
+
+
+def download(url, dest, retries=5, timeout=60):
+    """Download ``url`` to ``dest``, retrying on transient network errors.
+
+    A single ``urlopen`` with no timeout is fragile in CI: a momentary
+    runner-to-host connectivity blip (e.g. an IPv6 route that blackholes the
+    connection) hangs for the full kernel timeout and then kills the build. So
+    bound each attempt with a timeout and retry a few times with backoff. A
+    browser-like ``User-Agent`` is sent because some servers reject the default
+    ``Python-urllib`` agent.
+
+    Parameters
+    ----------
+    url : str
+        The URL to download.
+    dest : str | pathlib.Path
+        Local path to write the downloaded bytes to.
+    retries : int
+        Maximum number of attempts before giving up.
+    timeout : int
+        Per-attempt socket timeout, in seconds.
+
+    """
+    req = Request(url, headers={"User-Agent": "Mozilla/5.0 (pyprep CI)"})
+    last_err = None
+    for attempt in range(1, retries + 1):
+        try:
+            with urlopen(req, timeout=timeout) as resp, open(dest, "wb") as out:
+                shutil.copyfileobj(resp, out)
+            return
+        except (URLError, TimeoutError, ConnectionError) as err:
+            last_err = err
+            print(f"  attempt {attempt}/{retries} failed ({err})")
+            if attempt < retries:
+                time.sleep(2**attempt)
+    raise RuntimeError(
+        f"Failed to download '{url}' after {retries} attempts: {last_err}"
+    )
+
 
 # Initialize required directories
 
@@ -24,15 +65,12 @@ artifact_dir.mkdir(exist_ok=True)
 subject = "S004"
 run = "R01"
 eeg_filename = f"{subject}{run}.edf"
-eeg_url = f"https://www.physionet.org/files/eegmmidb/1.0.0/{subject}/{eeg_filename}?download"
+eeg_url = (
+    f"https://www.physionet.org/files/eegmmidb/1.0.0/{subject}/{eeg_filename}?download"
+)
 
 print("* Downloading EEG test data...")
-try:
-    mod_http = urlopen(eeg_url)
-    with open(eeg_filename, "wb") as out:
-        out.write(mod_http.read())
-except (URLError, HTTPError):
-    raise RuntimeError(f"Failed to download '{eeg_filename}'")
+download(eeg_url, eeg_filename)
 
 # Download and extract EEGLAB and MATLAB PREP.
 #
@@ -58,12 +96,7 @@ for name, url in pkgs.items():
 
     # Download .zip to temporary folder
     download_path = download_dir / f"{name}.zip"
-    try:
-        mod_http = urlopen(url)
-        with open(download_path, "wb") as out:
-            out.write(mod_http.read())
-    except (URLError, HTTPError):
-        raise RuntimeError(f"Failed to download '{url}'")
+    download(url, download_path)
 
     # Unzip downloaded file to MATLAB package directory
     with ZipFile(download_path, "r") as z:


### PR DESCRIPTION
Follow-up to #189 / #160. The new `matprep_artifacts` workflow failed on its first run on `main`, which also red-failed `Python tests`.

## Root cause

`tools/matprep/config/pipeline_setup.py` downloaded the test EEG (`S004R01.edf`) with a single raw `urlopen` — no timeout, no retry. On the CI run it hit a transient runner→PhysioNet **TCP connection timeout** (`Errno 110`, ~135s — the IPv6-route-blackhole signature on GitHub runners) and aborted the whole build. No artifacts were produced, so the rolling `matprep-artifacts` release was never published, which in turn 404s the downloads in `tests/test_matprep_compare.py`.

## Fix

**Fetch the recording via `mne.datasets.eegbci.load_data` instead of a raw download.** It is pooch-backed (retries + verifies the bytes against MNE's hash registry) and pulls from the *same* PhysioNet source (`physionet.org/files/eegmmidb/1.0.0/`) that the rest of pyprep's test suite already uses — so it's the identical file, fetched the same robust way. The workflow now `pip install`s `mne`; mne is used **only** to fetch the recording (MATLAB PREP still does all the processing, so the mne version has no effect on the artifact values).

The **EEGLAB/PREP archives** have no dataset fetcher, so they keep a small `download()` helper (bounded per-attempt timeout + retries with backoff + a real `User-Agent`) — a momentary blip on those hosts won't hard-fail the build either.

## Verification

- Ran the actual data-fetch path locally: `eegbci.load_data(4, 1)` → copies `S004R01.edf` at the exact expected 1,275,936 bytes, from the same PhysioNet URL.
- `pre-commit` (incl. `check-yaml` on the workflow) + `ruff check`/`ruff format` clean.

## After merge

The merge commit touches `tools/matprep/**`, so it auto-triggers `matprep_artifacts` again. This is the first run that will exercise the MATLAB install / PREP run / release-publish steps (the download killed earlier runs before that). Once it's green it publishes the `matprep-artifacts` release; the parallel `Python tests` job on the same commit will likely still 404 on that first pass, so re-run it once the artifact build is green. Self-sustaining thereafter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)