### PR TITLE
Add Python 3.14 support, bump tooling, fix a spurious warning

### DIFF
--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.13"]
+        python-version: ["3.14"]
     env:
       TZ: Europe/Berlin
       FORCE_COLOR: true

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -18,13 +18,13 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.13"]
+        python-version: ["3.14"]
         mne-version: [mne-stable]
 
         include:
           # Test mne development version only on ubuntu
           - platform: ubuntu-latest
-            python-version: "3.13"
+            python-version: "3.14"
             mne-version: mne-main
             run-as-extra: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-tags: true
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: check-docstring-first
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.2
+    rev: v0.15.17
     hooks:
       - id: ruff
         name: ruff check --fix
@@ -25,7 +25,7 @@ repos:
         files: ^(pyprep/|examples/|tests/)
 
   - repo: https://github.com/pappasam/toml-sort
-    rev: v0.24.3
+    rev: v0.24.4
     hooks:
       - id: toml-sort-fix
         files: pyproject.toml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-lts-latest
   tools:
-    python: "3.13"
+    python: "3.14"
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,11 @@ Changelog
 Bug
 ~~~
 - ``pyprep`` no longer calls :func:`logging.basicConfig` at import time (in :mod:`pyprep.reference`), which previously reconfigured the root logger of any downstream application that imported ``pyprep``, by `Stefan Appelhoff`_
+- :class:`~pyprep.Reference` no longer emits a spurious "No bad channels to interpolate" warning during robust referencing when there are no bad channels to interpolate, by `Stefan Appelhoff`_ (:gh:`192`)
+
+Code health
+~~~~~~~~~~~
+- Added support for Python 3.14 to the test matrix and package metadata, and bumped the pre-commit hooks and GitHub Actions used for development and CI, by `Stefan Appelhoff`_ (:gh:`192`)
 
 .. _changes_0_6_0:
 

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -640,6 +640,7 @@ class NoisyChannels:
         This is a PyPREP-only method not present in the original MATLAB PREP.
 
         A channel is considered "bad-by-psd" if:
+
         1. Its power in any frequency band (low: 1-15 Hz, mid: 15-30 Hz,
            high: 30-45 Hz) is abnormally HIGH compared to other channels, OR
         2. Its high-frequency band has more power than its low-frequency band

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -141,10 +141,11 @@ class Reference:
         # more than what we later actually account for (in interpolated channels).
         dummy = self.raw.copy()
         dummy.info["bads"] = self.noisy_channels["bad_all"]
-        if self.matlab_strict:
-            _eeglab_interpolate_bads(dummy)
-        else:
-            dummy.interpolate_bads()
+        if len(dummy.info["bads"]) > 0:
+            if self.matlab_strict:
+                _eeglab_interpolate_bads(dummy)
+            else:
+                dummy.interpolate_bads()
         self.reference_signal = np.nanmean(
             dummy.get_data(picks=self.reference_channels), axis=0
         )
@@ -205,10 +206,11 @@ class Reference:
 
         # Interpolate any channels flagged as bad following robust referencing
         bad_channels = self.raw.info["bads"]
-        if self.matlab_strict:
-            _eeglab_interpolate_bads(self.raw)
-        else:
-            self.raw.interpolate_bads()
+        if len(bad_channels) > 0:
+            if self.matlab_strict:
+                _eeglab_interpolate_bads(self.raw)
+            else:
+                self.raw.interpolate_bads()
 
         # Calculate and remove the new average reference following interpolation
         reference_correct = np.nanmean(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python",
   "Topic :: Scientific/Engineering",
 ]


### PR DESCRIPTION
Routine maintenance:

- Add Python 3.14 to the classifiers; bump the tested/built version 3.13 → 3.14 (tests, build, release, RTD).
- `pre-commit autoupdate`: ruff v0.15.2 → v0.15.17, toml-sort v0.24.3 → v0.24.4.
- Fix two RST docstring warnings in `find_bad_by_PSD`.
- Stop `Reference` emitting a spurious "No bad channels to interpolate" warning when there is nothing to interpolate.

`pre-commit`, `sphinx-build` (0 warnings), and `pytest -W error` (47 passed) are all clean.