### PR TITLE
[REL] Finalize changelog for 0.7.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,7 +21,7 @@ Here we list what's new in ``pyprep``.
 
 .. _changes_0_7_0:
 
-Version 0.7.0 (unreleased)
+Version 0.7.0 (2026-06-13)
 --------------------------
 
 Changelog


### PR DESCRIPTION
Prepares the 0.7.0 release per CONTRIBUTING: renames the unreleased changelog heading to `Version 0.7.0 (2026-06-13)`.

CITATION.cff already lists all 0.7.0 contributors, so the Authors section is unchanged. The version is derived from the git tag by hatch-vcs, so there is no version string to edit.

After merge, the remaining release steps need admin rights (annotated `0.7.0` tag, GitHub release, PyPI publish, then re-add a "current" heading for the next cycle).