### PR TITLE
start dev 0.8.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,15 @@ Here we list what's new in ``pyprep``.
 
 .. currentmodule:: pyprep
 
+.. _changes_0_8_0:
+
+Version 0.8.0 (unreleased)
+--------------------------
+
+Changelog
+~~~~~~~~~
+- nothing yet
+
 .. _changes_0_7_0:
 
 Version 0.7.0 (2026-06-13)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ exclude = [
 allow-direct-references = true  # allow specifying URLs in our dependencies
 
 [tool.hatch.version]
-raw-options = {version_scheme = "release-branch-semver"}
+raw-options = {local_scheme = "node-and-date", version_scheme = "no-guess-dev"}
 source = "vcs"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Post-0.7.0 release prep: re-add an unreleased changelog section for the next development cycle, per CONTRIBUTING.