### PR TITLE
Vectorize bandpass filtering in NoisyChannels._get_filtered_data

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,7 +26,7 @@ Version 0.8.0 (unreleased)
 
 Changelog
 ~~~~~~~~~
-- nothing yet
+- :meth:`~pyprep.NoisyChannels.find_bad_by_correlation` (and any other method that uses the internally band-pass-filtered signal) is now substantially faster: ``NoisyChannels._get_filtered_data`` filters all channels at once instead of channel-by-channel, with bit-identical output, by `Stefan Appelhoff`_ (:gh:`195`)
 
 .. _changes_0_7_0:
 

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -212,11 +212,7 @@ class NoisyChannels:
             amp=np.array([1, 1, 0, 0]),
             freq=np.array([0, 90 / self.sample_rate, 100 / self.sample_rate, 1]),
         )
-        EEG_filt = np.zeros_like(self.EEGData)
-        for i in range(EEG_filt.shape[0]):
-            EEG_filt[i, :] = signal.filtfilt(bandpass_filter, 1, self.EEGData[i, :])
-
-        return EEG_filt
+        return signal.filtfilt(bandpass_filter, 1, self.EEGData, axis=1)
 
     def get_bads(self, verbose=False, as_dict=False):
         """Get the names of all channels currently flagged as bad.


### PR DESCRIPTION
## Summary

Vectorize the bandpass filter in `NoisyChannels._get_filtered_data` by filtering all channels at once with `scipy.signal.filtfilt(..., axis=1)` instead of looping `filtfilt` over each channel into a pre-allocated `np.zeros_like` buffer.

The per-channel loop recomputed the FIR initial conditions (`lfilter_zi` → `linalg.solve`) once per channel; `axis=1` computes them once and runs the filter in C across all rows.

## Why

`_get_filtered_data` dominates the runtime of `find_bad_by_correlation` (and any path that needs the filtered signal). On an 18.5-min, 99-channel @ 500 Hz recording:

- `filtfilt` step: **9.98 s → 2.40 s (4.16×)** (clean wall-clock, median of 5)
- `find_bad_by_correlation`: **12.14 s → 5.06 s (2.40×)**
- It also drops the explicit full-size `np.zeros_like` output buffer.

## Correctness

Bit-for-bit identical output — `filtfilt` along `axis=1` applies the same per-row algorithm, and `lfilter_zi` depends only on the filter coefficients, not the data:

- `np.array_equal` with the old per-channel loop, maxdiff `0.0`, on the real recording and random arrays of shapes `(64, 9601)`, `(10, 1000)`, `(1, 5000)`, `(99, 553759)`.
- Full test suite passes (47 passed), including `tests/test_matprep_compare.py` (numeric MATLAB-PREP equivalence).
- `get_bads(as_dict=True)` and all `_extra_info` arrays unchanged on the real recording (reject `"omit"` and `None`) and the eegbci fixture (`matlab_strict` `False` and `True`).
