### PR TITLE
Detrend in place in NoisyChannels.__init__ to avoid full-array copies

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,7 +26,7 @@ Version 0.8.0 (unreleased)
 
 Changelog
 ~~~~~~~~~
-- nothing yet
+- :class:`~pyprep.NoisyChannels` now detrends the EEG signal in place during initialization, avoiding two transient full-size copies of the recording; :func:`pyprep.removeTrend.removeTrend` gained a ``copy`` keyword argument (default ``True``, preserving the previous behavior) to support this, by `Stefan Appelhoff`_ (:gh:`196`)
 
 .. _changes_0_7_0:
 

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -97,7 +97,10 @@ class NoisyChannels:
         self.sample_rate = raw.info["sfreq"]
         if do_detrend:
             self.raw_mne._data = removeTrend(
-                self.raw_mne.get_data(), self.sample_rate, matlab_strict=matlab_strict
+                self.raw_mne._data,
+                self.sample_rate,
+                matlab_strict=matlab_strict,
+                copy=False,
             )
         self.matlab_strict = matlab_strict
 

--- a/pyprep/removeTrend.py
+++ b/pyprep/removeTrend.py
@@ -18,6 +18,7 @@ def removeTrend(
     detrendCutoff=1.0,
     detrendChannels=None,
     matlab_strict=False,
+    copy=True,
 ):
     """Remove trends (i.e., slow drifts in baseline) from an array of EEG data.
 
@@ -40,6 +41,12 @@ def removeTrend(
         Whether or not detrending should strictly follow MATLAB PREP's internal
         math, ignoring any improvements made in PyPREP over the original code
         (see :ref:`matlab-diffs` for more details). Defaults to ``False``.
+    copy : bool
+        Whether to operate on a copy of the input data (``True``) or to filter
+        the input array in place (``False``). Filtering in place avoids
+        allocating a second full-size copy of the data, but modifies the input.
+        Only affects the (default) ``'high pass'`` non-``matlab_strict`` path.
+        Defaults to ``True``.
 
     Returns
     -------
@@ -75,6 +82,7 @@ def removeTrend(
                 l_freq=detrendCutoff,
                 h_freq=None,
                 picks=detrendChannels,
+                copy=copy,
             )
 
     elif detrendType.lower() == "high pass sinc":


### PR DESCRIPTION
## Summary

Detrend the EEG signal in place during `NoisyChannels.__init__`, avoiding two transient full-size copies of the recording during construction.

- `removeTrend` gains a `copy=True` keyword argument that is passed through to `mne.filter.filter_data`. The default (`copy=True`) preserves the exact current behavior for every existing caller.
- `NoisyChannels.__init__` now calls `removeTrend(self.raw_mne._data, ..., copy=False)` instead of `removeTrend(self.raw_mne.get_data(), ...)`.

## Why

The previous code allocated two avoidable full-array copies while detrending:

1. `get_data()` always returns a copy (verified: it does not share memory with `_data`).
2. `mne.filter.filter_data(copy=True)` allocates a separate output buffer.

Filtering in place removes both. On an 18.5-min, 99-channel @ 500 Hz recording (~439 MB), `filter_data` peaks at **+887 MB → +443 MB** (one full-array transient removed), and `__init__` drops from ~1.94 s to ~1.77 s.

The `matlab_strict` path already filters in place, so `copy` only affects the default (MNE high-pass) branch.

## Correctness

- `mne.filter.filter_data(copy=False)` is bit-identical to `copy=True` (verified `np.array_equal`); `copy` only controls whether MNE allocates a new array.
- Full test suite passes (47 passed), including `tests/test_matprep_compare.py`.
- `get_bads(as_dict=True)` and all `_extra_info` arrays unchanged on the real recording (reject `"omit"`/`None`) and the eegbci fixture (`matlab_strict` `False`/`True`).
