### PR TITLE
Log through pyprep's own logger namespace

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -51,3 +51,18 @@ The :mod:`~pyprep.ransac` module
    :toctree: generated/
 
    find_bad_by_ransac
+
+Logging
+=======
+
+pyprep logs at ``"INFO"`` through its own ``pyprep`` logger, which is configured
+when the package is imported. Use the function below to change the level, redirect
+the stream, or hand the records to your application's own handlers. The root logger
+is never configured.
+
+.. currentmodule:: pyprep
+
+.. autosummary::
+   :toctree: generated/
+
+   setup_logging

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,7 +26,11 @@ Version 0.8.0 (unreleased)
 
 Changelog
 ~~~~~~~~~
-- Nothing yet
+- ``pyprep`` now logs through its own ``pyprep`` logger, configured at import time to log at ``"INFO"`` through its own handler on :data:`sys.stdout`. The new :func:`pyprep.setup_logging` changes the level, redirects the stream, or hands the records over to the application's own handlers; the root logger is never configured. :mod:`pyprep.find_noisy_channels` and :mod:`pyprep.ransac` previously logged through MNE's logger, so :func:`mne.set_log_level` no longer silences them — use :func:`pyprep.setup_logging` instead, by `Stefan Appelhoff`_ (:gh:`209`)
+
+Bug
+~~~
+- :func:`pyprep.removeTrend.removeTrend` no longer logs to the root logger; its two messages now go through the ``pyprep.removeTrend`` logger like the rest of the package, by `Stefan Appelhoff`_ (:gh:`209`)
 
 .. _changes_0_7_1:
 

--- a/examples/run_full_prep.py
+++ b/examples/run_full_prep.py
@@ -21,6 +21,7 @@ import mne
 import numpy as np
 from mne.datasets import eegbci
 
+from pyprep import setup_logging
 from pyprep.prep_pipeline import PrepPipeline
 
 ###############################################################################
@@ -30,8 +31,12 @@ from pyprep.prep_pipeline import PrepPipeline
 # We use subject 4, run 1 from the PhysioNet BCI2000 (eegbci) dataset. This is
 # a fairly noisy recording, which makes it a good candidate for demonstrating
 # PREP. The data are 64-channel EEG sampled at 160 Hz.
+#
+# MNE and pyprep each log at ``"INFO"`` by default; we turn both down to keep
+# this example's output short.
 
 mne.set_log_level("WARNING")
+setup_logging("WARNING")
 
 edf_fpath = eegbci.load_data(subjects=4, runs=1, update_path=True)[0]
 raw = mne.io.read_raw_edf(edf_fpath, preload=True)

--- a/examples/run_prep_in_stages.py
+++ b/examples/run_prep_in_stages.py
@@ -26,6 +26,7 @@ import mne
 import numpy as np
 from mne.datasets import eegbci
 
+from pyprep import setup_logging
 from pyprep.prep_pipeline import PrepPipeline
 
 ###############################################################################
@@ -35,8 +36,12 @@ from pyprep.prep_pipeline import PrepPipeline
 # As in the "Run the full PREP" example, we use subject 4, run 1 from the
 # PhysioNet BCI2000 (eegbci) dataset: a fairly noisy 64-channel recording
 # sampled at 160 Hz.
+#
+# MNE and pyprep each log at ``"INFO"`` by default; we turn both down to keep
+# this example's output short.
 
 mne.set_log_level("WARNING")
+setup_logging("WARNING")
 
 edf_fpath = eegbci.load_data(subjects=4, runs=1, update_path=True)[0]
 raw = mne.io.read_raw_edf(edf_fpath, preload=True)

--- a/pyprep/__init__.py
+++ b/pyprep/__init__.py
@@ -4,9 +4,14 @@
 # SPDX-License-Identifier: MIT
 
 import pyprep.ransac as ransac  # noqa: F401
+from pyprep._logging import setup_logging  # noqa: F401
 from pyprep.find_noisy_channels import NoisyChannels  # noqa: F401
 from pyprep.prep_pipeline import PrepPipeline  # noqa: F401
 from pyprep.reference import Reference  # noqa: F401
+
+# Loud by default, like MNE. Applications turn it down with
+# setup_logging("WARNING") or take over the output with setup_logging(propagate=True).
+setup_logging()
 
 try:
     from importlib.metadata import version

--- a/pyprep/_logging.py
+++ b/pyprep/_logging.py
@@ -1,0 +1,62 @@
+"""Configure the logging of pyprep."""
+
+# Authors: The PyPREP developers
+# SPDX-License-Identifier: MIT
+
+import logging
+import sys
+
+_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+_LOGGER_NAME = "pyprep"
+
+
+class _StreamHandler(logging.StreamHandler):
+    """Marker subclass identifying the handler that pyprep installed."""
+
+
+def setup_logging(level="INFO", stream=None, propagate=False):
+    """Configure the ``pyprep`` logger.
+
+    This is called at import time with its defaults, so pyprep logs at ``"INFO"``
+    to :data:`sys.stdout` without any setup. Call it again to change that.
+
+    Parameters
+    ----------
+    level : int | str
+        Level for the ``pyprep`` logger. Pass ``"WARNING"`` to keep only warnings
+        and errors, or ``"DEBUG"`` for more detail. Defaults to ``"INFO"``.
+    stream : file-like | None
+        Destination for pyprep's own handler. ``None`` keeps the current
+        destination, which is :data:`sys.stdout` on a fresh interpreter. Ignored
+        when ``propagate`` is ``True``.
+    propagate : bool
+        ``False`` (the default) prints through pyprep's own handler and stops the
+        records there, so an application that configures the root logger does not
+        see them twice. ``True`` removes that handler and passes the records to
+        ancestor loggers instead, letting the application's own handlers format
+        and route them.
+
+    Notes
+    -----
+    Only the ``pyprep`` namespace is configured; the root logger is never touched.
+    MNE has its own ``mne`` logger, controlled separately through
+    :func:`mne.set_log_level`. Before pyprep 0.8.0 several pyprep modules logged
+    through MNE's logger, so ``mne.set_log_level`` used to silence them; use this
+    function instead.
+    """
+    logger = logging.getLogger(_LOGGER_NAME)
+    logger.setLevel(level)
+    own = [h for h in logger.handlers if isinstance(h, _StreamHandler)]
+    if propagate:
+        for handler in own:
+            logger.removeHandler(handler)
+            handler.close()
+    elif own:
+        if stream is not None:
+            for handler in own:
+                handler.setStream(stream)
+    else:
+        handler = _StreamHandler(stream or sys.stdout)
+        handler.setFormatter(logging.Formatter(_FORMAT))
+        logger.addHandler(handler)
+    logger.propagate = propagate

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -3,14 +3,18 @@
 # Authors: The PyPREP developers
 # SPDX-License-Identifier: MIT
 
+import logging
+
 import mne
 import numpy as np
-from mne.utils import check_random_state, logger
+from mne.utils import check_random_state
 from scipy import signal
 
 from pyprep.ransac import find_bad_by_ransac
 from pyprep.removeTrend import removeTrend
 from pyprep.utils import _filter_design, _mad, _mat_iqr, _mat_quantile
+
+logger = logging.getLogger(__name__)
 
 
 class NoisyChannels:

--- a/pyprep/ransac.py
+++ b/pyprep/ransac.py
@@ -3,9 +3,11 @@
 # Authors: The PyPREP developers
 # SPDX-License-Identifier: MIT
 
+import logging
+
 import numpy as np
 from mne.channels.interpolation import _make_interpolation_matrix
-from mne.utils import ProgressBar, check_random_state, logger
+from mne.utils import ProgressBar, check_random_state
 
 from pyprep.utils import (
     _correlate_arrays,
@@ -14,6 +16,8 @@ from pyprep.utils import (
     _split_list,
     _verify_free_ram,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def find_bad_by_ransac(

--- a/pyprep/removeTrend.py
+++ b/pyprep/removeTrend.py
@@ -10,6 +10,8 @@ import numpy as np
 
 from pyprep.utils import _eeglab_create_highpass, _eeglab_fir_filter
 
+logger = logging.getLogger(__name__)
+
 
 def removeTrend(
     EEG,
@@ -109,7 +111,7 @@ def removeTrend(
         dn = np.round(sample_rate * stepSize)
 
         if dn > n or dn < 1:
-            logging.error(
+            logger.error(
                 "Step size should be less than the window size and "
                 "contain at least 1 sample"
             )
@@ -122,8 +124,8 @@ def removeTrend(
         EEG = np.transpose(EEG)
 
     else:
-        logging.warning(
-            "No filtering/detreding performed since the detrend type did not match"
+        logger.warning(
+            "No filtering/detrending performed since the detrend type did not match"
         )
 
     return EEG

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,28 @@
 # Authors: The PyPREP developers
 # SPDX-License-Identifier: MIT
 
+import logging
+
 import mne
 import numpy as np
 import pytest
 from mne.datasets import eegbci
+
+
+@pytest.fixture(autouse=True)
+def configure_pyprep_logging():
+    """Quiet pyprep's own INFO output and let ``caplog`` capture its records.
+
+    pyprep configures its logger at import time with ``propagate = False``, which
+    keeps records away from the root-level handler that ``caplog`` installs.
+    """
+    logger = logging.getLogger("pyprep")
+    level, propagate = logger.level, logger.propagate
+    logger.setLevel("WARNING")
+    logger.propagate = True
+    yield
+    logger.setLevel(level)
+    logger.propagate = propagate
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,84 @@
+"""Test the configuration of pyprep's logger."""
+
+# Authors: The PyPREP developers
+# SPDX-License-Identifier: MIT
+
+import io
+import logging
+import subprocess
+import sys
+
+import pytest
+
+from pyprep import setup_logging
+from pyprep._logging import _StreamHandler
+
+# Emitted from a clean interpreter, so the logger state of this test session
+# cannot influence what is observed.
+_FRESH = (
+    "import logging, pyprep; "
+    "logging.getLogger('pyprep.mod').info('hello'); "
+    "print('root handlers:', logging.getLogger().handlers)"
+)
+
+
+@pytest.fixture
+def restore_logger():
+    """Restore the pyprep logger after a test reconfigured it."""
+    logger = logging.getLogger("pyprep")
+    handlers, level, propagate = logger.handlers[:], logger.level, logger.propagate
+    yield logger
+    logger.handlers[:] = handlers
+    logger.setLevel(level)
+    logger.propagate = propagate
+
+
+def _run_fresh():
+    """Import pyprep in a clean interpreter and return its output."""
+    return subprocess.run(
+        [sys.executable, "-c", _FRESH], capture_output=True, text=True, check=True
+    )
+
+
+def test_visible_by_default():
+    """Test that importing pyprep is enough to see its log messages."""
+    completed = _run_fresh()
+    assert "[INFO] pyprep.mod: hello" in completed.stdout
+    assert "hello" not in completed.stderr
+
+
+def test_root_logger_untouched():
+    """Test that pyprep does not configure the root logger."""
+    completed = _run_fresh()
+    assert "root handlers: []" in completed.stdout
+
+
+def test_setup_logging_level(restore_logger):
+    """Test that the level set by setup_logging is respected."""
+    stream = io.StringIO()
+    setup_logging(level="WARNING", stream=stream)
+    logger = logging.getLogger("pyprep.mod")
+    logger.info("invisible")
+    logger.warning("visible")
+    assert "invisible" not in stream.getvalue()
+    assert "visible" in stream.getvalue()
+
+
+def test_setup_logging_is_idempotent(restore_logger):
+    """Test that repeated setup_logging calls do not duplicate output."""
+    stream = io.StringIO()
+    setup_logging(stream=stream)
+    n_handlers = len(restore_logger.handlers)
+    setup_logging(stream=stream)
+    logging.getLogger("pyprep.mod").info("once")
+    assert len(restore_logger.handlers) == n_handlers
+    assert stream.getvalue().count("once") == 1
+
+
+def test_setup_logging_propagate_hands_over(restore_logger, caplog):
+    """Test that propagate=True lets an application handle the records."""
+    setup_logging(propagate=True)
+    assert not [h for h in restore_logger.handlers if isinstance(h, _StreamHandler)]
+    with caplog.at_level(logging.INFO, logger="pyprep.mod"):
+        logging.getLogger("pyprep.mod").info("handed over")
+    assert "handed over" in caplog.text


### PR DESCRIPTION
`pyprep` used three logging mechanisms at once: `find_noisy_channels` and `ransac` logged
through MNE's logger (`from mne.utils import logger`), `reference` through a handler-less
`pyprep.reference` logger, and `removeTrend` straight to the **root** logger. So pyprep's
records were attributed to `mne`, could only be silenced through `mne.set_log_level`, and two
of them surfaced as `WARNING:root:...`.

pyprep now owns a `pyprep` logger, configured when the package is imported: `INFO`, its own
handler on `sys.stdout`, `propagate = False`. That is the model MNE uses for its own logger,
and the root logger stays untouched. `setup_logging` is the knob:

```python
pyprep.setup_logging("WARNING")       # warnings and errors only
pyprep.setup_logging(propagate=True)  # let the application's handlers print them
```

## Behaviour change

`mne.set_log_level()` no longer affects pyprep. Downstream code that relied on it — including
the two examples and the test fixtures in this repo — needs `pyprep.setup_logging()` instead.
The changelog says so.

## Notes

- The four `logger.info` calls in `reference` become visible for the first time.
- `removeTrend`'s message said "detreding"; fixed while touching the line.
- `tests/conftest.py` gains an autouse fixture that quiets pyprep for the suite and restores
  propagation, without which `caplog` cannot see pyprep records at all: they no longer reach
  the root-level handler pytest installs.

## Verification

`pytest`: 53 passed. In a fresh interpreter with no logging configuration, `import pyprep` is
now enough to get formatted `[INFO] pyprep.<module>: ...` on stdout, while
`logging.getLogger().handlers` is still `[]`.
