### PR TITLE
Accept level names in any case

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,7 +26,7 @@ Version 0.9.0 (unreleased)
 
 Changelog
 ~~~~~~~~~
-- Nothing yet
+- :func:`pyprep.setup_logging` now accepts level names in any case, so ``setup_logging("warning")`` works like :func:`mne.set_log_level` instead of raising ``ValueError``, by `Stefan Appelhoff`_ (:gh:`210`)
 
 .. _changes_0_8_0:
 

--- a/pyprep/_logging.py
+++ b/pyprep/_logging.py
@@ -24,7 +24,8 @@ def setup_logging(level="INFO", stream=None, propagate=False):
     ----------
     level : int | str
         Level for the ``pyprep`` logger. Pass ``"WARNING"`` to keep only warnings
-        and errors, or ``"DEBUG"`` for more detail. Defaults to ``"INFO"``.
+        and errors, or ``"DEBUG"`` for more detail. Names are case-insensitive, as
+        in :func:`mne.set_log_level`. Defaults to ``"INFO"``.
     stream : file-like | None
         Destination for pyprep's own handler. ``None`` keeps the current
         destination, which is :data:`sys.stdout` on a fresh interpreter. Ignored
@@ -45,7 +46,8 @@ def setup_logging(level="INFO", stream=None, propagate=False):
     function instead.
     """
     logger = logging.getLogger(_LOGGER_NAME)
-    logger.setLevel(level)
+    # The stdlib only knows upper-case level names; MNE accepts any case, so do we.
+    logger.setLevel(level.upper() if isinstance(level, str) else level)
     own = [h for h in logger.handlers if isinstance(h, _StreamHandler)]
     if propagate:
         for handler in own:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -64,6 +64,13 @@ def test_setup_logging_level(restore_logger):
     assert "visible" in stream.getvalue()
 
 
+@pytest.mark.parametrize("level", ["warning", "WARNING", "Warning", logging.WARNING])
+def test_setup_logging_accepts_any_level_spelling(restore_logger, level):
+    """Level names are case-insensitive, and plain ints work too."""
+    setup_logging(level=level, stream=io.StringIO())
+    assert restore_logger.level == logging.WARNING
+
+
 def test_setup_logging_is_idempotent(restore_logger):
     """Test that repeated setup_logging calls do not duplicate output."""
     stream = io.StringIO()


### PR DESCRIPTION
`setup_logging("warning")` raised, because the stdlib only knows upper-case level names:

```python
>>> pyprep.setup_logging("warning")
ValueError: Unknown level: 'warning'
```

`mne.set_log_level("warning")` accepts it, lower case is the spelling people reach for, and it
is what the sibling packages in this stack show in their docs. So the level is upper-cased when
it is a string, and passed through untouched when it is an int.

Tested for `"warning"`, `"WARNING"`, `"Warning"` and `logging.WARNING`.

`pytest tests/test_logging.py`: 57 passed. `ruff check` clean.
