### PR TITLE
Reconcile the drifted parameter docstrings

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -39,6 +39,10 @@ Bug
 ~~~
 - :func:`pyprep.removeTrend.removeTrend` now raises a :class:`ValueError` for a ``'local detrend'`` step size that is larger than the window or smaller than one sample, instead of logging an error and detrending with it anyway, by `Stefan Appelhoff`_ (:gh:`211`)
 
+Doc
+~~~
+- The ``ransac``, ``channel_wise`` and ``matlab_strict`` parameters of :class:`~pyprep.PrepPipeline`, :class:`~pyprep.Reference`, :class:`~pyprep.NoisyChannels` and :func:`~pyprep.ransac.find_bad_by_ransac` were documented as ``bool | None`` in twelve places although each has a plain bool default and never accepts ``None``. They are now documented as ``bool``; the entries in :meth:`~pyprep.NoisyChannels.find_all_bads`, where ``None`` means "use the value from instantiation", keep ``bool | None``. The copied descriptions of ``ransac``, ``random_state``, ``matlab_strict``, ``reject_by_annotation`` and ``interpolate_bads`` had drifted apart between those same classes and were reconciled, by `Stefan Appelhoff`_ (:gh:`212`)
+
 .. _changes_0_8_0:
 
 Version 0.8.0 (2026-08-08)

--- a/pyprep/find_noisy_channels.py
+++ b/pyprep/find_noisy_channels.py
@@ -306,7 +306,7 @@ class NoisyChannels:
             detection considerably. If ``None`` (default), then the value at
             instantiation of the ``NoisyChannels`` class is taken (defaults
             to ``True``), else the instantiation value is overwritten.
-        channel_wise : bool | None
+        channel_wise : bool
             Whether RANSAC should predict signals for chunks of channels over the
             entire signal length ("channel-wise RANSAC", see `max_chunk_size`
             parameter). If ``False``, RANSAC will instead predict signals for all
@@ -845,7 +845,7 @@ class NoisyChannels:
         corr_window_secs : float | None
             The duration (in seconds) of each RANSAC correlation window. Defaults
             to 5 seconds.
-        channel_wise : bool | None
+        channel_wise : bool
             Whether RANSAC should predict signals for chunks of channels over the
             entire signal length ("channel-wise RANSAC", see `max_chunk_size`
             parameter). If ``False``, RANSAC will instead predict signals for all

--- a/pyprep/prep_pipeline.py
+++ b/pyprep/prep_pipeline.py
@@ -47,7 +47,9 @@ class PrepPipeline:
         Digital montage of EEG data.
     ransac : bool
         Whether or not to use RANSAC for noisy channel detection in addition to
-        the other methods in :class:`~pyprep.NoisyChannels`. Defaults to True.
+        the other methods in :class:`~pyprep.NoisyChannels`. RANSAC can detect
+        bad channels that other methods are unable to catch, but also slows down
+        noisy channel detection considerably. Defaults to ``True``.
     channel_wise : bool
         Whether RANSAC should predict signals for chunks of channels over the
         entire signal length ("channel-wise RANSAC", see `max_chunk_size`
@@ -65,10 +67,10 @@ class PrepPipeline:
         host system. If using window-wise RANSAC (the default) or not using
         RANSAC at all, this parameter has no effect. Defaults to ``None``.
     random_state : {int, None, np.random.RandomState} | None
-        The random seed at which to initialize the class. If random_state is
-        an int, it will be used as a seed for RandomState.
-        If None, the seed will be obtained from the operating system
-        (see RandomState for details). Default is None.
+        The random seed at which to initialize the class. This can be ``None``,
+        an integer, or a :class:`~numpy.random.RandomState` object. If ``None``,
+        a random seed will be obtained from the operating system. Defaults to
+        ``None``.
     filter_kwargs : {dict, None} | None
         Optional keywords arguments to be passed on to mne.filter.notch_filter.
         Do not set the "x", Fs", and "freqs" arguments via the filter_kwargs
@@ -86,7 +88,7 @@ class PrepPipeline:
     matlab_strict : bool
         Whether or not PyPREP should strictly follow MATLAB PREP's internal
         math, ignoring any improvements made in PyPREP over the original code
-        (see :ref:`matlab-diffs` for more details). Defaults to False.
+        (see :ref:`matlab-diffs` for more details). Defaults to ``False``.
 
     Attributes
     ----------
@@ -278,7 +280,7 @@ class PrepPipeline:
             entry of the ``prep_params`` passed to :class:`PrepPipeline` is used.
         interpolate_bads : bool, optional
             Whether or not any remaining bad channels following robust referencing
-            should be interpolated. Defaults to ``True``.
+            should be interpolated or left as-is. Defaults to ``True``.
 
         """
         if max_iterations is None:

--- a/pyprep/prep_pipeline.py
+++ b/pyprep/prep_pipeline.py
@@ -45,10 +45,10 @@ class PrepPipeline:
               perform during robust referencing. Defaults to ``4``.
     montage : mne.channels.DigMontage
         Digital montage of EEG data.
-    ransac : bool | None
+    ransac : bool
         Whether or not to use RANSAC for noisy channel detection in addition to
         the other methods in :class:`~pyprep.NoisyChannels`. Defaults to True.
-    channel_wise : bool | None
+    channel_wise : bool
         Whether RANSAC should predict signals for chunks of channels over the
         entire signal length ("channel-wise RANSAC", see `max_chunk_size`
         parameter). If ``False``, RANSAC will instead predict signals for all
@@ -83,7 +83,7 @@ class PrepPipeline:
         full recording is used. This is useful when recordings contain breaks
         or movement artifacts that shouldn't influence channel rejection
         decisions.
-    matlab_strict : bool | None
+    matlab_strict : bool
         Whether or not PyPREP should strictly follow MATLAB PREP's internal
         math, ignoring any improvements made in PyPREP over the original code
         (see :ref:`matlab-diffs` for more details). Defaults to False.

--- a/pyprep/ransac.py
+++ b/pyprep/ransac.py
@@ -98,9 +98,9 @@ def find_bad_by_ransac(
         has no effect. Defaults to ``None``.
     random_state : {int, None, np.random.RandomState} | None
         The random seed with which to generate random samples of channels during
-        RANSAC. If random_state is an int, it will be used as a seed for RandomState.
-        If ``None``, the seed will be obtained from the operating system
-        (see RandomState for details). Defaults to ``None``.
+        RANSAC. This can be ``None``, an integer, or a
+        :class:`~numpy.random.RandomState` object. If ``None``, a random seed
+        will be obtained from the operating system. Defaults to ``None``.
     matlab_strict : bool
         Whether or not RANSAC should strictly follow MATLAB PREP's internal
         math, ignoring any improvements made in PyPREP over the original code

--- a/pyprep/ransac.py
+++ b/pyprep/ransac.py
@@ -81,7 +81,7 @@ def find_bad_by_ransac(
     corr_window_secs : float | None
         The duration (in seconds) of each RANSAC correlation window. Defaults to
         5 seconds.
-    channel_wise : bool | None
+    channel_wise : bool
         Whether RANSAC should predict signals for chunks of channels over the
         entire signal length ("channel-wise RANSAC", see `max_chunk_size`
         parameter). If ``False``, RANSAC will instead predict signals for all
@@ -101,7 +101,7 @@ def find_bad_by_ransac(
         RANSAC. If random_state is an int, it will be used as a seed for RandomState.
         If ``None``, the seed will be obtained from the operating system
         (see RandomState for details). Defaults to ``None``.
-    matlab_strict : bool | None
+    matlab_strict : bool
         Whether or not RANSAC should strictly follow MATLAB PREP's internal
         math, ignoring any improvements made in PyPREP over the original code
         (see :ref:`matlab-diffs` for more details). Defaults to ``False``.

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -31,7 +31,9 @@ class Reference:
         - ``reref_chs``
     ransac : bool
         Whether or not to use RANSAC for noisy channel detection in addition to
-        the other methods in :class:`~pyprep.NoisyChannels`. Defaults to True.
+        the other methods in :class:`~pyprep.NoisyChannels`. RANSAC can detect
+        bad channels that other methods are unable to catch, but also slows down
+        noisy channel detection considerably. Defaults to ``True``.
     channel_wise : bool
         Whether RANSAC should predict signals for chunks of channels over the
         entire signal length ("channel-wise RANSAC", see `max_chunk_size`
@@ -49,18 +51,22 @@ class Reference:
         host system. If using window-wise RANSAC (the default) or not using
         RANSAC at all, this parameter has no effect. Defaults to ``None``.
     random_state : {int, None, np.random.RandomState} | None
-        The random seed at which to initialize the class. If random_state is
-        an int, it will be used as a seed for RandomState.
-        If None, the seed will be obtained from the operating system
-        (see RandomState for details). Default is None.
+        The random seed at which to initialize the class. This can be ``None``,
+        an integer, or a :class:`~numpy.random.RandomState` object. If ``None``,
+        a random seed will be obtained from the operating system. Defaults to
+        ``None``.
     reject_by_annotation : {None, 'omit'} | None
         How to handle BAD-annotated time segments (annotations starting with
         "BAD" or "bad") during channel quality assessment. If ``'omit'``,
-        annotated segments are excluded. Defaults to ``None`` (ignore).
+        annotated segments are excluded from analysis (clean segments are
+        concatenated). If ``None`` (default), annotations are ignored and the
+        full recording is used. This is useful when recordings contain breaks
+        or movement artifacts that shouldn't influence channel rejection
+        decisions.
     matlab_strict : bool
         Whether or not PyPREP should strictly follow MATLAB PREP's internal
-        math, ignoring any improvements made in PyPREP over the original code.
-        Defaults to False.
+        math, ignoring any improvements made in PyPREP over the original code
+        (see :ref:`matlab-diffs` for more details). Defaults to ``False``.
 
     References
     ----------

--- a/pyprep/reference.py
+++ b/pyprep/reference.py
@@ -29,10 +29,10 @@ class Reference:
         Parameters of PREP which include at least the following keys:
         - ``ref_chs``
         - ``reref_chs``
-    ransac : bool | None
+    ransac : bool
         Whether or not to use RANSAC for noisy channel detection in addition to
         the other methods in :class:`~pyprep.NoisyChannels`. Defaults to True.
-    channel_wise : bool | None
+    channel_wise : bool
         Whether RANSAC should predict signals for chunks of channels over the
         entire signal length ("channel-wise RANSAC", see `max_chunk_size`
         parameter). If ``False``, RANSAC will instead predict signals for all
@@ -57,7 +57,7 @@ class Reference:
         How to handle BAD-annotated time segments (annotations starting with
         "BAD" or "bad") during channel quality assessment. If ``'omit'``,
         annotated segments are excluded. Defaults to ``None`` (ignore).
-    matlab_strict : bool | None
+    matlab_strict : bool
         Whether or not PyPREP should strictly follow MATLAB PREP's internal
         math, ignoring any improvements made in PyPREP over the original code.
         Defaults to False.

--- a/pyprep/removeTrend.py
+++ b/pyprep/removeTrend.py
@@ -39,7 +39,7 @@ def removeTrend(
     detrendChannels : {list, None} | None
         List of the indices of all channels that require detrending/filtering.
         If ``None``, all channels are used (default).
-    matlab_strict : bool | None
+    matlab_strict : bool
         Whether or not detrending should strictly follow MATLAB PREP's internal
         math, ignoring any improvements made in PyPREP over the original code
         (see :ref:`matlab-diffs` for more details). Defaults to ``False``.

--- a/pyprep/utils.py
+++ b/pyprep/utils.py
@@ -435,7 +435,7 @@ def _correlate_arrays(a, b, matlab_strict=False):
         A 2-D array to correlate with `a`.
     b : np.ndarray
         A 2-D array to correlate with `b`.
-    matlab_strict : bool | None
+    matlab_strict : bool
         Whether or not correlations should be calculated identically to MATLAB
         PREP (i.e., without mean subtraction) instead of by traditional Pearson
         product-moment correlation (see Notes for details). Defaults to


### PR DESCRIPTION
Documentation only — no change to behaviour, signatures or defaults.

Several parameters are documented in more than one place, because their
descriptions were copy-pasted between `NoisyChannels`, `PrepPipeline`,
`Reference`, `find_bad_by_ransac` and `removeTrend`. The copies have since
drifted: markup was lost, a cross-reference was dropped, and one type string
is wrong in twelve places. This reconciles them.

### Type strings

`ransac`, `channel_wise` and `matlab_strict` were rendered as `bool | None` in
twelve places. All twelve have a plain bool default and never accept `None`, so
the API docs told the reader they could pass it. They now say `bool`.

The entries that keep `bool | None` are the ones in
`NoisyChannels.find_all_bads`, where `None` really does mean "use the value
from instantiation", or where the parameter is documented as ignored.

### Prose

- `ransac` in `PrepPipeline` and `Reference` had lost the sentence warning that
  RANSAC slows noisy channel detection down considerably, and left its default
  unmarked.
- `random_state` in `PrepPipeline`, `Reference` and `find_bad_by_ransac` said
  "see RandomState for details" without linking anything, and marked up none of
  its literals. All three now link `~numpy.random.RandomState`.
- `matlab_strict` in `Reference` was the only description of that flag in the
  package that did not point at `:ref:`matlab-diffs``, the page listing the
  improvements it turns off.
- `reject_by_annotation` in `Reference` no longer said what `'omit'` does to the
  data or why one would ask for it.
- `interpolate_bads` in `PrepPipeline.robust_reference` now names the
  alternative to interpolating, as the `Reference` copy already did.

Each site keeps the opening sentence that is genuinely its own: what the random
seed is used for differs between the pipeline, the reference and RANSAC, and
`matlab_strict` is described in terms of the code the reader is looking at
("PyPREP", "RANSAC", "detrending").

The wording fixes get no changelog entry, but the type strings do: a user
reading the rendered API was told three boolean flags accept `None`.

### Open questions

- **Based on `quiet-logging-by-default`, not `main`.** #211 is still open and
  touches two of the same files, though not these lines. Retarget to `main`
  once it lands.
- **No shared docdict.** Repeating a parameter description per function is
  right for numpydoc — a reader of `NoisyChannels.__init__` wants the text
  inline, not a pointer elsewhere. Deduplicating for real means an MNE-style
  `docdict` + `fill_doc` substituting one canonical string at import time,
  which is a separate and much larger change. Until then these copies can drift
  again.
- **`{int, None} | None` and `{None, 'omit'} | None` left alone.** The trailing
  `| None` is redundant in both, and in every similar type string in the
  package. Untangling that is its own decision, not part of a wording fix.
- `PrepPipeline.robust_reference` documents `max_iterations` by deferring to the
  `prep_params` dict, while `Reference` states the number outright. Both
  readings are defensible for their own call signature, so neither was touched.
- Descriptions that differ deliberately were left differing: `channel_wise` and
  `max_chunk_size` drop the "has no effect if not using RANSAC" clause inside
  the RANSAC functions themselves, and the private RANSAC helpers do not render
  in the docs at all.

### Verification

`pytest` (61 passed), `pre-commit run --all-files`, and a clean
`make html` in `docs/` with no warnings.
